### PR TITLE
Make AsyncStorage type more specific

### DIFF
--- a/app/react-native/src/preview/index.tsx
+++ b/app/react-native/src/preview/index.tsx
@@ -16,8 +16,8 @@ import getHost from './rn-host-detect';
 const STORAGE_KEY = 'lastOpenedStory';
 
 interface AsyncStorage {
-  getItem: <T>(key: string) => Promise<T>;
-  setItem: <T>(key: string, value: T) => Promise<void>;
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
 }
 
 export type Params = {


### PR DESCRIPTION
Issue:
Passing AsyncStorage from `@react-native-community/async-storage` results in type errors.

## What I did
I made the types more specific to match the ones from the library.

## How to test

Just compile the basic example with typescript

```
import AsyncStorage from "@react-native-community/async-storage";

// import stories
configure(() => {
}, module);

// Refer to https://github.com/storybookjs/storybook/tree/master/app/react-native#start-command-parameters
// To find allowed options for getStorybookUI
const StorybookUIRoot = getStorybookUI({
  // Disable asyncStorage to avoid warning temporarily until this is fixed:
  asyncStorage: AsyncStorage,
});

```

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
