### PR TITLE
bug: fix typescript error during bootstrap

### DIFF
--- a/app/react-native/src/preview/index.tsx
+++ b/app/react-native/src/preview/index.tsx
@@ -190,7 +190,7 @@ More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react
       try {
         let value = this._asyncStorageStoryId;
         if (!value && this._asyncStorage) {
-          value = JSON.parse(await this._asyncStorage.getItem<string>(STORAGE_KEY));
+          value = JSON.parse(await this._asyncStorage.getItem(STORAGE_KEY));
           this._asyncStorageStoryId = value;
         }
 


### PR DESCRIPTION
Issue: #66 "Bootstrap fails on fresh clone"

## What I did

Removed the type argument used on get item. The async storage type is defined as 

```
interface AsyncStorage {
  getItem: (key: string) => Promise<string | null>;
  setItem: (key: string, value: string) => Promise<void>;
}
```

As you can see the getItem function doesn't have a type argument so this was causing an error when building for example when running the bootstrap.

## How to test

- Is this testable with Jest or Chromatic screenshots? no
- Does this need a new example in the kitchen sink apps? no
- Does this need an update to the documentation? no

Run `yarn bootstrap --core`  and it should no longer fail.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
