### PR TITLE
fix: temporarily remove smoke test since it's broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,6 @@ workflows:
       - lint:
           requires:
             - build
-      - native-smoke-tests:
-          requires:
-            - build
       - test:
           requires:
             - build


### PR DESCRIPTION

## What I did

remove the ci step that runs the smoke test since there is some issues with it