### PR TITLE
fix: potential fix for status bar covering stories on android+expo

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.tsx
@@ -8,6 +8,7 @@ import {
   SafeAreaView,
   Dimensions,
   TouchableOpacity,
+  StatusBar,
 } from 'react-native';
 import styled from '@emotion/native';
 import addons from '@storybook/addons';
@@ -126,7 +127,9 @@ export default class OnDeviceUI extends PureComponent<OnDeviceUIProps, OnDeviceU
     const previewStyles = [flex, getPreviewScale(this.animatedValue, slideBetweenAnimation)];
 
     return (
-      <SafeAreaView style={flex}>
+      <SafeAreaView
+        style={[flex, { paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }]}
+      >
         <KeyboardAvoidingView
           enabled={!shouldDisableKeyboardAvoidingView || tabOpen !== PREVIEW}
           behavior={IS_IOS ? 'padding' : null}

--- a/app/react-native/src/preview/components/OnDeviceUI/index.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.tsx
@@ -32,6 +32,12 @@ import {
 const ANIMATION_DURATION = 300;
 const IS_IOS = Platform.OS === 'ios';
 
+// @ts-ignore: Property 'Expo' does not exist on type 'Global'
+// eslint-disable-next-line no-underscore-dangle
+const getExpoRoot = () => global.Expo || global.__expo || global.__exponent;
+export const IS_EXPO = getExpoRoot() !== undefined;
+const IS_ANDROID = Platform.OS === 'android';
+
 interface OnDeviceUIProps {
   stories: any;
   url?: string;
@@ -128,7 +134,7 @@ export default class OnDeviceUI extends PureComponent<OnDeviceUIProps, OnDeviceU
 
     return (
       <SafeAreaView
-        style={[flex, { paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }]}
+        style={[flex, { paddingTop: IS_ANDROID && IS_EXPO ? StatusBar.currentHeight : 0 }]}
       >
         <KeyboardAvoidingView
           enabled={!shouldDisableKeyboardAvoidingView || tabOpen !== PREVIEW}


### PR DESCRIPTION
Issue: #67 

## What I did

added a padding top for the safe area view when using android, this needs testing for both expo android and regular native android