### PR TITLE
fix: emit type declarations when building so type info is not lost

### DIFF
--- a/scripts/compile-tsc.js
+++ b/scripts/compile-tsc.js
@@ -6,7 +6,7 @@ const shell = require('shelljs');
 function getCommand(watch) {
   const tsc = path.join(__dirname, '..', 'node_modules', '.bin', 'tsc');
 
-  const args = ['--outDir ./dist', '--listEmittedFiles true'];
+  const args = ['--outDir ./dist', '--listEmittedFiles true', '--declaration true'];
 
   if (watch) {
     args.push('-w');


### PR DESCRIPTION
Issue: None

## What I did

I noticed that I wasn't getting types for any of the packages locally and after investigation the difference is that type declarations were present in the "Dist" folder of builds in previous versions and since the migration to the new repo this doesn't seem to be the case. The fix for this is to add `--declarations true` to tsc arguments.


