### PR TITLE
fix: ondevice select knob undefined value causes key error

### DIFF
--- a/addons/ondevice-knobs/src/types/Select.js
+++ b/addons/ondevice-knobs/src/types/Select.js
@@ -39,6 +39,7 @@ class SelectType extends React.Component {
           initValue={knob.value}
           onChange={(option) => onChange(option.key)}
           animationType="none"
+          keyExtractor={({ key, label }) => `${label}-${key}`}
         >
           <Input
             editable={false}


### PR DESCRIPTION
Issue: #109 

## What I did

Make the key extractor a combination of key and label instead of just key.

## How to test

- create a knob with multiple selects that have undefined values

