### PR TITLE
Fix type annotation for storiesOf method

### DIFF
--- a/app/react-native/src/index.ts
+++ b/app/react-native/src/index.ts
@@ -1,5 +1,7 @@
 /* eslint-disable prefer-destructuring */
+import { StoryApi } from '@storybook/addons';
 import { ClientApi } from '@storybook/client-api';
+import { ReactNode } from 'react';
 import Preview from './preview';
 
 const preview = new Preview();
@@ -16,5 +18,5 @@ export const getStorybook: ClientApi['getStorybook'] = preview.api().getStoryboo
 export const getStorybookUI = preview.getStorybookUI;
 export const raw: ClientApi['raw'] = preview.api().raw.bind(preview);
 
-export const storiesOf = (kind: string, module: NodeModule) =>
+export const storiesOf = (kind: string, module: NodeModule): StoryApi<ReactNode> =>
   rawStoriesOf(kind, module).addParameters({ framework: 'react-native' });


### PR DESCRIPTION
Issue: #123 

## What I did
Fixed the type annotation for the `storiesOf` method.

## How to test
Convert `Button.stories.js` to a typescript file and verify there are no type errors.

- Is this testable with Jest or Chromatic screenshots?
  - no
- Does this need a new example in the kitchen sink apps?
  - Probably wouldn't hurt to have a typescript example, but i think that's beyond the scope of this PR
- Does this need an update to the documentation?
  - There could absolutely be more information in the docs about how to use typescript with this library, but again, i think that's beyond the scope of this PR

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
