### PR TITLE
Change async-storage text for a new one

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -170,20 +170,20 @@ The description doc block on DocsPage has also been updated. To see how to confi
 
 ### React Native Async Storage
 
-Starting from version React Native 0.59, Async Storage is deprecated in React Native itself. The new @react-native-community/async-storage module requires native installation, and we don't want to have it as a dependency for React Native Storybook.
+Starting from version React Native 0.59, Async Storage is deprecated in React Native itself. The new react-native-async-storage/async-storage module requires native installation, and we don't want to have it as a dependency for React Native Storybook.
 
 To avoid that now you have to manually pass asyncStorage to React Native Storybook with asyncStorage prop. To notify users we are displaying a warning about it.
 
 Solution:
 
-- Use `require('@react-native-community/async-storage').AsyncStorage` for React Native v0.59 and above.
+- Use `require('react-native-async-storage/async-storage').AsyncStorage` for React Native v0.59 and above.
 - Use `require('react-native').AsyncStorage` for React Native v0.58 or below.
 - Use `null` to disable Async Storage completely.
 
 ```javascript
 getStorybookUI({
   ...
-  asyncStorage: require('@react-native-community/async-storage').AsyncStorage || require('react-native').AsyncStorage || null
+  asyncStorage: require('react-native-async-storage/async-storage').AsyncStorage || require('react-native').AsyncStorage || null
 });
 ```
 


### PR DESCRIPTION
Issue:
@react-native-community/async-storage library was deprecated

## What I did
Since @react-native-community/async-storage library was deprecated and Async Storage has moved to a new organization: https://github.com/react-native-async-storage/async-storage I decided to update documentation about this.

## How to test
read a text :)
