### PR TITLE
refactor: Refactors Addons.tsx to a function component

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/addons/Addons.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/addons/Addons.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useState } from 'react';
 import { SafeAreaView } from 'react-native';
 import styled from '@emotion/native';
 import { addons } from '@storybook/addons';
@@ -17,45 +17,26 @@ const Container = styled.View(({ theme }) => ({
   backgroundColor: theme.backgroundColor,
 }));
 
-export default class Addons extends PureComponent<{}, { addonSelected: string }> {
-  panels = addons.getElements('panel');
+export default React.memo(() => {
+  const panels = addons.getElements('panel');
+  const [addonSelected, setAddonSelected] = useState<string | null>(Object.keys(panels)[0] || null);
 
-  constructor(props: {}) {
-    super(props);
-
-    this.state = {
-      addonSelected: Object.keys(this.panels)[0] || null,
-    };
-  }
-
-  onPressAddon = (addonSelected: string) => {
-    this.setState({ addonSelected });
-  };
-
-  render() {
-    const { addonSelected } = this.state;
-
-    if (Object.keys(this.panels).length === 0) {
-      return (
-        <SafeAreaView style={{ flex: 1 }}>
-          <NoAddonContainer>
-            <Label>No addons loaded.</Label>
-          </NoAddonContainer>
-        </SafeAreaView>
-      );
-    }
-
+  if (Object.keys(panels).length === 0) {
     return (
-      <Container>
-        <SafeAreaView style={{ flex: 1 }}>
-          <AddonsList
-            onPressAddon={this.onPressAddon}
-            panels={this.panels}
-            addonSelected={addonSelected}
-          />
-          <AddonWrapper addonSelected={addonSelected} panels={this.panels} />
-        </SafeAreaView>
-      </Container>
+      <SafeAreaView style={{ flex: 1 }}>
+        <NoAddonContainer>
+          <Label>No addons loaded.</Label>
+        </NoAddonContainer>
+      </SafeAreaView>
     );
   }
-}
+
+  return (
+    <Container>
+      <SafeAreaView style={{ flex: 1 }}>
+        <AddonsList onPressAddon={setAddonSelected} panels={panels} addonSelected={addonSelected} />
+        <AddonWrapper addonSelected={addonSelected} panels={panels} />
+      </SafeAreaView>
+    </Container>
+  );
+});

--- a/app/react-native/src/preview/components/OnDeviceUI/addons/Addons.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/addons/Addons.tsx
@@ -17,7 +17,7 @@ const Container = styled.View(({ theme }) => ({
   backgroundColor: theme.backgroundColor,
 }));
 
-export default React.memo(() => {
+const Addons = () => {
   const panels = addons.getElements('panel');
   const [addonSelected, setAddonSelected] = useState<string | null>(Object.keys(panels)[0] || null);
 
@@ -39,4 +39,5 @@ export default React.memo(() => {
       </SafeAreaView>
     </Container>
   );
-});
+};
+export default React.memo(Addons);


### PR DESCRIPTION
Issue: https://github.com/storybookjs/react-native/issues/179

## What I did
Refactored app/react-native/src/preview/components/OnDeviceUI/addons/Addons.tsx to a function component as planned 

## How to test
~~Was unable to run the examples on Android and iOS, both with and without these changes. Opened https://github.com/storybookjs/react-native/issues/186 with details.~~ Run the native examples and check that the Addons tab renders correctly

- Does this need a new example in examples/native? **In my opinion, no**
- Does this need an update to the documentation? **In my opinion, no**

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
