### PR TITLE
fix: Fix https://github.com/storybookjs/react-native/issues/120

### DIFF
--- a/addons/ondevice-knobs/package.json
+++ b/addons/ondevice-knobs/package.json
@@ -30,11 +30,12 @@
     "@emotion/native": "^10.0.14",
     "@storybook/addons": "^6",
     "@storybook/core-events": "^6",
+    "@react-native-community/datetimepicker": "^3.5.2",
+    "@react-native-picker/picker": "^1.16.3",
     "core-js": "^3.0.1",
     "deep-equal": "^1.0.1",
     "prop-types": "^15.7.2",
-    "react-native-modal-datetime-picker": "^7.4.2",
-    "react-native-modal-selector": "^2.0.2",
+    "react-native-modal-datetime-picker": "^10.0.0",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {

--- a/addons/ondevice-knobs/src/types/Select.js
+++ b/addons/ondevice-knobs/src/types/Select.js
@@ -29,8 +29,6 @@ class SelectType extends React.Component {
 
     const options = this.getOptions(knob);
 
-    const active = options.filter(({ key }) => knob.value === key)[0];
-
     return (
       <View>
         <Picker selectedValue={knob.value} onValueChange={(itemValue) => onChange(itemValue)}>

--- a/addons/ondevice-knobs/src/types/Select.js
+++ b/addons/ondevice-knobs/src/types/Select.js
@@ -3,8 +3,8 @@
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import React from 'react';
-import ModalPicker from 'react-native-modal-selector';
 import styled from '@emotion/native';
+import { Picker } from '@react-native-picker/picker';
 
 const Input = styled.TextInput(({ theme }) => ({
   borderWidth: 1,
@@ -30,24 +30,14 @@ class SelectType extends React.Component {
     const options = this.getOptions(knob);
 
     const active = options.filter(({ key }) => knob.value === key)[0];
-    const selected = active && active.label;
 
     return (
       <View>
-        <ModalPicker
-          data={options}
-          initValue={knob.value}
-          onChange={(option) => onChange(option.key)}
-          animationType="none"
-          keyExtractor={({ key, label }) => `${label}-${key}`}
-        >
-          <Input
-            editable={false}
-            value={selected}
-            autoCapitalize="none"
-            underlineColorAndroid="transparent"
-          />
-        </ModalPicker>
+        <Picker selectedValue={knob.value} onValueChange={(itemValue) => onChange(itemValue)}>
+          {options.map(({ key, label }) => (
+            <Picker.Item key={`${label}-${key}`} value={key} label={label} />
+          ))}
+        </Picker>
       </View>
     );
   }

--- a/examples/native/ios/Podfile.lock
+++ b/examples/native/ios/Podfile.lock
@@ -452,9 +452,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 60baaee9d10a9d225389062decbbf2b0bd6420ce
+  FBReactNativeSpec: ba3bc03e12cb0bea22d69a8a9458eaf3e92521a8
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -462,7 +462,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c

--- a/yarn.lock
+++ b/yarn.lock
@@ -4306,6 +4306,13 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
+"@react-native-community/datetimepicker@^3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.5.2.tgz#8e6feb30f2620e5abdf565d5fe74c0c04edcf6ae"
+  integrity sha512-TWRuAtr/DnrEcRewqvXMLea2oB+YF+SbtuYLHguALLxNJQLl/RFB7aTNZeF+OoH75zKFqtXECXV1/uxQUpA+sg==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native-community/eslint-config@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-2.0.0.tgz#35dcc529a274803fc4e0a6b3d6c274551fb91774"
@@ -4329,6 +4336,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.1.0.tgz#e42b1bef12d2415411519fd528e64b593b1363dc"
   integrity sha512-W/J0fNYVO01tioHjvYWQ9m6RgndVtbElzYozBq1ZPrHO/iCzlqoySHl4gO/fpCl9QEFjvJfjPgtPMTMlsoq5DQ==
+
+"@react-native-picker/picker@^1.16.3":
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.16.3.tgz#22750f8d44465432845fa59ce20e69761029b6ef"
+  integrity sha512-Qt40DBg7IEhBN5x2DYPV3B26j5fNhVZcpCestr1IuirneMNtOaIyA9+nPYniL/OBzd9YbpUKbS7XSy/MM9bP3w==
 
 "@react-native/assets@1.0.0":
   version "1.0.0"
@@ -17445,7 +17457,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -17821,13 +17833,6 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-native-animatable@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"
-  integrity sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==
-  dependencies:
-    prop-types "^15.7.2"
-
 react-native-codegen@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.0.6.tgz#b3173faa879cf71bfade8d030f9c4698388f6909"
@@ -17837,28 +17842,12 @@ react-native-codegen@^0.0.6:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
-react-native-modal-datetime-picker@^7.4.2:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-7.6.1.tgz#463eaece1af98aa0b2fce00dab6cd203f89b86da"
-  integrity sha512-Ovq0p20Tbw6uWGV0VIDcCQ5qTaHxC9gEcYmB2a4fD1ksCSwCil9RJBEhC7VirvplvAGCKOKs3bblaKFmhiOBkg==
+react-native-modal-datetime-picker@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-10.0.0.tgz#1a424c0ed277ab76621542af4efa4f357ed2a740"
+  integrity sha512-uKi1K3nUWJ1UWssLsDt8s7KpfFFlZ0MaP91wf3rFG07woscVu70m1Db0f1v6s3YY01UW+q+8ZD+Y2Hp3o+UCvQ==
   dependencies:
     prop-types "^15.7.2"
-    react-native-modal "^11.0.2"
-
-react-native-modal-selector@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-modal-selector/-/react-native-modal-selector-2.0.3.tgz#7872b61cde0680541b7ff6e3787dd1b3bfc79179"
-  integrity sha512-d1ejtVi40p34p3eDC55r93Qb1UWUq2oSuIU+GRBhbrcwNcxWbstRAU8Him2BYbns5g/jzyeOQOJzyEnKCMniBw==
-  dependencies:
-    prop-types "^15.5.10"
-
-react-native-modal@^11.0.2:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-11.10.0.tgz#94a6d3a2428ba5228cfb4dc174cacea79c871591"
-  integrity sha512-syRYDJYSh16bR37R5EKU9T/wC+5bEOfF17IUqf5URdhbEDd+hxyMInC++l45E8oI+MtdOaEp9yAws5xDqk8dnA==
-  dependencies:
-    prop-types "^15.6.2"
-    react-native-animatable "1.3.3"
 
 react-native-simple-markdown@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Issue: Fix https://github.com/storybookjs/react-native/issues/120 by changing knobs dependencies to ones that don't break Expo's "yarn web"

## What I did
Changed dependencies of `ondevice-knobs` according to the suggested fix at https://github.com/storybookjs/react-native/issues/120#issuecomment-721388959 . `react-native-modal-selector` did not have a compatible version (there's an open PR from May, https://github.com/peacechen/react-native-modal-selector/pull/162), so changed it to `@react-native-picker/picker`.

## How to test
Smoke testing can be done with https://github.com/lauriharpf/react-native-storybook-expo-knobs-test , which was created based on instructions at https://github.com/storybookjs/react-native/issues/120 . Try this:

1. Pull https://github.com/lauriharpf/react-native-storybook-expo-knobs-test
1. `npm install -g expo-cli`
1. Pull this branch
1. `yarn dev` in the root of this branch
1. Edit the [reference to @storybook/addon-ondevice-knobs in package.json](https://github.com/lauriharpf/react-native-storybook-expo-knobs-test/blob/main/package.json#L15) of https://github.com/lauriharpf/react-native-storybook-expo-knobs-test to point to your local `ondevice-knobs` (pulled and set up in previous two steps)
1. In the root of https://github.com/lauriharpf/react-native-storybook-expo-knobs-test, run `yarn install`, followed by `yarn start-storybook` and then `yarn web` in another terminal
1. Once Expo's web has loaded, open the "Knobs Example > with knobs" from the Storybook and use the two knobs (select & datepicker).
1. Run the Expo project on iOS and Android, repeating the experimenting with "Knobs Example > with knobs"
1. Compare the results to the ones with running `next-6.0` branch instead of this branch.

- Does this need a new example in examples/native? **Yes, we should add examples of the knobs to next-6.0**. Tired to do that, but couldn't get any addons to appear. Any help is appreciated!
- Does this need an update to the documentation? **No, not in my opinion**

## Known issues and limitations

### Select issue on Android
For some reason the select values (apple, banana, cherry) are not visible on Android. What I see is this:
![Screen Shot 2021-06-27 at 19 09 42](https://user-images.githubusercontent.com/6605505/123551780-dafe9a00-d77b-11eb-88a3-9e7e9976f16c.png)

The iOS view looks fine and the values are selectable:
![Screen Shot 2021-06-27 at 19 10 18](https://user-images.githubusercontent.com/6605505/123551822-07b2b180-d77c-11eb-882f-d8258d12ddb7.png)

### Datepicker does not work in Expo web
The datepicker does not open when clicking on it. Developer tools shows the following error: `react-native-logs.fx.ts:22 DateTimePicker is not supported on: web`

### Expo issue on iOS
For some reason, the "Knobs Example > with knobs" story breaks for me in Expo on iOS with this error:

```
Error: React.Children.only expected to receive a single React element child.

This error is located at:
    in TouchableHighlight (at TouchableHighlight.js:383)
    in ForwardRef (at Button/index.js:6)
    in Button (at KnobsExample.stories.js:51)
    in RCTView (at View.js:34)
    in View (created by StoryView)
    in StoryView (created by OnDeviceUI)
    in RCTView (at View.js:34)
    in View (created by Context.Consumer)
    in emotion(View) (created by OnDeviceUI)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (created by OnDeviceUI)
    in RCTView (at View.js:34)
    in View (at createAnimatedComponent.js:165)
    in AnimatedComponent (at createAnimatedComponent.js:215)
    in ForwardRef(AnimatedComponentWrapper) (created by OnDeviceUI)
    in RCTView (at View.js:34)
    in View (created by AbsolutePositionedKeyboardAwareView)
    in RCTView (at View.js:34)
    in View (created by AbsolutePositionedKeyboardAwareView)
    in AbsolutePositionedKeyboardAwareView (created by OnDeviceUI)
    in RCTView (at View.js:34)
    in View (at KeyboardAvoidingView.js:204)
    in KeyboardAvoidingView (created by OnDeviceUI)
    in RCTSafeAreaView (at SafeAreaView.js:51)
    in ForwardRef(SafeAreaView) (created by OnDeviceUI)
    in OnDeviceUI (created by StorybookRoot)
    in ThemeProvider (created by StorybookRoot)
    in StorybookRoot (created by ExpoRoot)
    in ExpoRoot (at renderApplication.js:45)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:106)
    in DevAppContainer (at AppContainer.js:121)
    in RCTView (at View.js:34)
    in View (at AppContainer.js:132)
    in AppContainer (at renderApplication.js:39)
at node_modules/react-native/Libraries/Core/ExceptionsManager.js:104:6 in reportException
at node_modules/react-native/Libraries/Core/ExceptionsManager.js:171:19 in handleException
at node_modules/react-native/Libraries/Core/setUpErrorHandling.js:24:6 in handleError
at node_modules/expo-error-recovery/build/ErrorRecovery.fx.js:12:21 in ErrorUtils.setGlobalHandler$argument_0
at node_modules/core-js/modules/es.promise.js:117:28 in microtask$argument_0
at node_modules/core-js/internals/microtask.js:27:10 in flush
at [native code]:null in flushedQueue
at [native code]:null in invokeCallbackAndReturnFlushedQueue
```

![Screen Shot 2021-06-27 at 19 02 32](https://user-images.githubusercontent.com/6605505/123551407-45aed600-d77a-11eb-86a2-40b0bf1b6152.png)

This seems to happen when I kill the iOS emulator and Expo, then restart the iOS emulator via Expo. Doing **any** edit (e.g. just changing comments and saving) to `KnobsExample.stories.js` fixes the problem, but it always reappears. Don't know what is going on and if that is related to the changes or not.
 
<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
