### PR TITLE
feat: First initial poking towards re-adding Select control

### DIFF
--- a/addons/ondevice-controls/src/ControlsPanel.tsx
+++ b/addons/ondevice-controls/src/ControlsPanel.tsx
@@ -55,9 +55,10 @@ const ControlsPanel = ({ api }: { api: API }) => {
   const showWarning = !(hasControls && isArgsStory);
   const argsObject = hasControls
     ? Object.entries(argsfromHook).reduce((prev, [name, value]) => {
+        console.log({ [name]: argTypes[name], argsfromHook });
         return {
           ...prev,
-          [name]: { name, type: argTypes[name]?.control?.type, value },
+          [name]: { ...argTypes?.[name], name, type: argTypes[name]?.control?.type, value },
         };
       }, {})
     : {};

--- a/addons/ondevice-controls/src/hooks.ts
+++ b/addons/ondevice-controls/src/hooks.ts
@@ -32,7 +32,11 @@ export const useArgs = (
     [storyId, storyStore]
   );
   const resetArgs = useCallback(
-    (argNames?: string[]) => storyStore.resetStoryArgs(storyId, argNames),
+    (argNames?: string[]) => {
+      storyStore.resetStoryArgs(storyId, argNames);
+      //TODO: remove this if possible
+      storyStore._channel.emit(FORCE_RE_RENDER);
+    },
     [storyId, storyStore]
   );
   return [args, updateArgs, resetArgs];

--- a/addons/ondevice-controls/src/types/Select.tsx
+++ b/addons/ondevice-controls/src/types/Select.tsx
@@ -15,15 +15,21 @@ const Input = styled.TextInput(({ theme }) => ({
 export interface SelectProps {
   arg: {
     name: string;
-    value: string;
+    value: any;
     options: Array<any> | Record<string, any>;
-    selectV2: boolean;
+    control: {
+      labels?: Record<string, string>;
+    };
   };
   onChange: (value: any) => void;
 }
 
-const getOptions = ({ options }: SelectProps['arg']) => {
+//TODO: mapping
+const getOptions = ({ options, control: { labels } }: SelectProps['arg']) => {
   if (Array.isArray(options)) {
+    if (labels) {
+      return options.map((val) => ({ key: val, label: labels[val] || val }));
+    }
     return options.map((val) => ({ key: val, label: val }));
   }
 
@@ -33,19 +39,19 @@ const getOptions = ({ options }: SelectProps['arg']) => {
   }));
 };
 
-const SelectType = (props: SelectProps) => {
-  console.log('propit');
-  console.log(JSON.stringify(props));
-  const { arg, onChange } = props;
+const SelectType = ({ arg, onChange }: SelectProps) => {
+  const { value } = arg;
   const options = getOptions(arg);
-  const active = options.filter(({ key }) => arg.value === key)[0];
+
+  const active = options.find(({ key }) => value === key);
+
   const selected = active && active.label;
 
   return (
     <View>
       <ModalPicker
         data={options}
-        initValue={arg.value}
+        initValue={value}
         onChange={(option) => onChange(option.key)}
         animationType="none"
         keyExtractor={({ key, label }) => `${label}-${key}`}

--- a/addons/ondevice-controls/src/types/Select.tsx
+++ b/addons/ondevice-controls/src/types/Select.tsx
@@ -1,5 +1,3 @@
-/* eslint no-underscore-dangle: 0 */
-
 import { View } from 'react-native';
 import React from 'react';
 import ModalPicker from 'react-native-modal-selector';
@@ -15,7 +13,7 @@ const Input = styled.TextInput(({ theme }) => ({
 }));
 
 export interface SelectProps {
-  knob: {
+  arg: {
     name: string;
     value: string;
     options: Array<any> | Record<string, any>;
@@ -24,54 +22,47 @@ export interface SelectProps {
   onChange: (value: any) => void;
 }
 
-class SelectType extends React.Component<SelectProps> {
-  static defaultProps = {
-    knob: {},
-    onChange: (value) => value,
-  };
-
-  static serialize = (value) => value;
-
-  static deserialize = (value) => value;
-
-  getOptions = ({ options }) => {
-    if (Array.isArray(options)) {
-      return options.map((val) => ({ key: val, label: val }));
-    }
-
-    return Object.keys(options).map((key) => ({
-      label: key,
-      key: options[key],
-    }));
-  };
-
-  render() {
-    const { knob, onChange } = this.props;
-
-    const options = this.getOptions(knob);
-
-    const active = options.filter(({ key }) => knob.value === key)[0];
-    const selected = active && active.label;
-
-    return (
-      <View>
-        <ModalPicker
-          data={options}
-          initValue={knob.value}
-          onChange={(option) => onChange(option.key)}
-          animationType="none"
-          keyExtractor={({ key, label }) => `${label}-${key}`}
-        >
-          <Input
-            editable={false}
-            value={selected}
-            autoCapitalize="none"
-            underlineColorAndroid="transparent"
-          />
-        </ModalPicker>
-      </View>
-    );
+const getOptions = ({ options }: SelectProps['arg']) => {
+  if (Array.isArray(options)) {
+    return options.map((val) => ({ key: val, label: val }));
   }
-}
+
+  return Object.keys(options).map((key) => ({
+    label: key,
+    key: options[key],
+  }));
+};
+
+const SelectType = (props: SelectProps) => {
+  console.log('propit');
+  console.log(JSON.stringify(props));
+  const { arg, onChange } = props;
+  const options = getOptions(arg);
+  const active = options.filter(({ key }) => arg.value === key)[0];
+  const selected = active && active.label;
+
+  return (
+    <View>
+      <ModalPicker
+        data={options}
+        initValue={arg.value}
+        onChange={(option) => onChange(option.key)}
+        animationType="none"
+        keyExtractor={({ key, label }) => `${label}-${key}`}
+      >
+        <Input
+          editable={false}
+          value={selected}
+          autoCapitalize="none"
+          underlineColorAndroid="transparent"
+        />
+      </ModalPicker>
+    </View>
+  );
+};
+
+SelectType.serialize = (value) => value;
+
+SelectType.deserialize = (value) => value;
 
 export default SelectType;

--- a/addons/ondevice-controls/src/types/index.ts
+++ b/addons/ondevice-controls/src/types/index.ts
@@ -3,7 +3,7 @@ import NumberType from './Number';
 import ColorType from './Color';
 // import BooleanType from './Boolean';
 // import ObjectType from './Object';
-// import SelectType from './Select';
+import SelectType from './Select';
 // import ArrayType from './Array';
 // import DateType from './Date';
 // import ButtonType from './Button';
@@ -15,7 +15,7 @@ export default {
   color: ColorType,
   // boolean: BooleanType,
   // object: ObjectType,
-  // select: SelectType,
+  select: SelectType,
   // array: ArrayType,
   // date: DateType,
   // button: ButtonType,

--- a/examples/native/components/CSFExample/SelectExample.stories.tsx
+++ b/examples/native/components/CSFExample/SelectExample.stories.tsx
@@ -2,25 +2,25 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react-native';
 import { SelectExample } from './SelectExample';
 
-const arrows = { ArrowUp: '⬆', ArrowDown: '⬇', ArrowLeft: '◀', ArrowRight: '▶' };
+const ArrowUp = '⬆';
+const ArrowDown = '⬇';
+const ArrowLeft = '⬅️';
+const ArrowRight = '➡️';
+const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };
 
 const SelectExampleMeta: ComponentMeta<typeof SelectExample> = {
   title: 'Select Example',
   component: SelectExample,
   argTypes: {
     arrow: {
-      options: ['1', '2'], //Object.keys(arrows),
-      //mapping: arrows,
+      options: [ArrowUp, ArrowDown, ArrowLeft, ArrowRight],
       control: {
         type: 'select',
-        //     labels: {
-        //       ArrowUp: 'Up',
-        //       ArrowDown: 'Down',
-        //       ArrowLeft: 'Left',
-        //       ArrowRight: 'Right',
       },
-      //   },
     },
+  },
+  parameters: {
+    notes: 'currently mapping is not working.',
   },
 };
 
@@ -31,5 +31,28 @@ type SelectExampleStory = ComponentStory<typeof SelectExample>;
 export const Basic: SelectExampleStory = (args) => <SelectExample {...args} />;
 
 Basic.args = {
-  arrow: '',
+  arrow: ArrowLeft,
 };
+
+export const WithLabels: SelectExampleStory = (args) => <SelectExample {...args} />;
+
+WithLabels.args = {
+  arrow: arrows.ArrowUp,
+};
+
+WithLabels.argTypes = {
+  arrow: {
+    options: Object.values(arrows),
+    control: {
+      type: 'select',
+      labels: {
+        [ArrowUp]: 'Up',
+        [ArrowDown]: 'Down',
+        [ArrowLeft]: 'Left',
+        [ArrowRight]: 'Right',
+      },
+    },
+  },
+};
+
+//TODO: mapping

--- a/examples/native/components/CSFExample/SelectExample.stories.tsx
+++ b/examples/native/components/CSFExample/SelectExample.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react-native';
+import { SelectExample } from './SelectExample';
+
+const arrows = { ArrowUp: '⬆', ArrowDown: '⬇', ArrowLeft: '◀', ArrowRight: '▶' };
+
+const SelectExampleMeta: ComponentMeta<typeof SelectExample> = {
+  title: 'Select Example',
+  component: SelectExample,
+  argTypes: {
+    arrow: {
+      options: ['1', '2'], //Object.keys(arrows),
+      //mapping: arrows,
+      control: {
+        type: 'select',
+        //     labels: {
+        //       ArrowUp: 'Up',
+        //       ArrowDown: 'Down',
+        //       ArrowLeft: 'Left',
+        //       ArrowRight: 'Right',
+      },
+      //   },
+    },
+  },
+};
+
+export default SelectExampleMeta;
+
+type SelectExampleStory = ComponentStory<typeof SelectExample>;
+
+export const Basic: SelectExampleStory = (args) => <SelectExample {...args} />;
+
+Basic.args = {
+  arrow: '',
+};

--- a/examples/native/components/CSFExample/SelectExample.tsx
+++ b/examples/native/components/CSFExample/SelectExample.tsx
@@ -1,0 +1,10 @@
+import React, { FunctionComponent } from 'react';
+import { Text } from 'react-native';
+
+interface Props {
+  arrow: string;
+}
+
+export const SelectExample: FunctionComponent<Props> = ({ arrow }) => (
+  <Text>Selected: {arrow}</Text>
+);

--- a/examples/native/ios/Podfile.lock
+++ b/examples/native/ios/Podfile.lock
@@ -459,7 +459,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 60baaee9d10a9d225389062decbbf2b0bd6420ce
+  FBReactNativeSpec: ba3bc03e12cb0bea22d69a8a9458eaf3e92521a8
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c


### PR DESCRIPTION
Issue: #177

## What I did
This is just a first, **very** initial and rudimentary draft towards re-enabling `Select`. **Note that it doesn't work** at its current state, just sharing it as a "hey, this is where I left off"-state in case there would be something that would help. Don't seem to get the options as props and couldn't yet figure out why.

While working on this, I noticed that controls seems to now have an "Options" structure in the main storybook (see https://github.com/storybookjs/storybook/blob/6584de334f4159305adc23ef73ac9e62e59833c2/lib/components/src/controls/options/Options.tsx). So this probably needs a similar structure?

(Note also the xxxExample-naming; this was done prior to our discussion in another PR; lets go with what we decided there)

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native? **Yes, we need to add one**
- Does this need an update to the documentation? **Not sure**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
