### PR TITLE
fix: Fixes #211 (After opening the keyboard the android UI shrinks)

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/absolute-positioned-keyboard-aware-view.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/absolute-positioned-keyboard-aware-view.tsx
@@ -1,13 +1,5 @@
-import React, { ReactNode, useRef, useEffect } from 'react';
-import {
-  Platform,
-  Keyboard,
-  Dimensions,
-  View,
-  LayoutChangeEvent,
-  KeyboardEvent,
-  StyleSheet,
-} from 'react-native';
+import React, { ReactNode } from 'react';
+import { View, LayoutChangeEvent, StyleSheet } from 'react-native';
 
 export interface PreviewDimens {
   width: number;
@@ -20,46 +12,6 @@ type Props = {
   children: ReactNode;
 };
 
-const useIsKeyboardOpen = (previewWidth: number) => {
-  const keyboardOpen = useRef(false);
-  useEffect(() => {
-    const keyboardDidShowHandler = (e: KeyboardEvent) => {
-      if (Platform.OS === 'android') {
-        // There is bug in RN android that keyboardDidShow event is called when you go from portrait to landscape.
-        // To make sure that this is keyboard event we check screen width
-        if (previewWidth === e.endCoordinates.width) {
-          keyboardOpen.current = true;
-        }
-      }
-    };
-
-    const keyboardDidHideHandler = () => {
-      if (keyboardOpen.current) {
-        keyboardOpen.current = false;
-      }
-    };
-
-    // When rotating screen from portrait to landscape with keyboard open on android it calls keyboardDidShow, but doesn't call
-    // keyboardDidHide. To avoid issues we set keyboardOpen to false immediately on keyboardChange.
-    const removeKeyboardOnOrientationChange = () => {
-      if (Platform.OS === 'android') {
-        keyboardOpen.current = false;
-      }
-    };
-
-    const keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', keyboardDidShowHandler);
-    const keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', keyboardDidHideHandler);
-    Dimensions.addEventListener('change', removeKeyboardOnOrientationChange);
-    return () => {
-      keyboardDidShowListener.remove();
-      keyboardDidHideListener.remove();
-      Dimensions.removeEventListener('change', removeKeyboardOnOrientationChange);
-    };
-  }, [previewWidth]);
-
-  return keyboardOpen.current;
-};
-
 // Android changes screen size when keyboard opens.
 // To avoid issues we use absolute positioned element with predefined screen size
 const AbsolutePositionedKeyboardAwareView = ({
@@ -67,15 +19,11 @@ const AbsolutePositionedKeyboardAwareView = ({
   previewDimensions: { width, height },
   children,
 }: Props) => {
-  const keyboardOpen = useIsKeyboardOpen(width);
-
   const onLayoutHandler = ({ nativeEvent }: LayoutChangeEvent) => {
-    if (!keyboardOpen) {
-      onLayout({
-        height: nativeEvent.layout.height,
-        width: nativeEvent.layout.width,
-      });
-    }
+    onLayout({
+      height: nativeEvent.layout.height,
+      width: nativeEvent.layout.width,
+    });
   };
 
   return (

--- a/examples/native/ios/Podfile.lock
+++ b/examples/native/ios/Podfile.lock
@@ -459,7 +459,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 60baaee9d10a9d225389062decbbf2b0bd6420ce
+  FBReactNativeSpec: ba3bc03e12cb0bea22d69a8a9458eaf3e92521a8
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c


### PR DESCRIPTION
Issue: #211 

## What I did
Removed 

## How to test
The steps to reproduce this issue on the Android emulator were:

0. Run the React Native examples (under examples/native) on Android
1. Open the story Navigator.
2. Select the "Basic" story.
3. Open "Addons -> Controls"
4. Click on the "first" field so that the keyboard comes up.
5. Click back to "Navigator"

### What happened
The story list in the navigator gets truncated a lot (seems to only occupy ~50% or so of the screen) after Step 5.

### What happens now after the fix
The story list doesn't get truncated; it looks the same it did after Step 1.

### Other

- Does this need a new example in examples/native? **no**
- Does this need an update to the documentation? **no**

The code this PR removes was introduced in https://github.com/storybookjs/react-native/commit/e413ec2e05103033e0db7e1e33f7c0a4e988fae6 . While testing (both on Android and iOS), I didn't notice any issues caused by removing this code. It is of course possible that there is a case that I've missed, but the code this PR removes clearly causes an issue in a common use case.

### UX with this branch
https://user-images.githubusercontent.com/6605505/125475611-ab4deae6-3873-4ed6-95f4-974c2a356c96.mov

### UX in the next-6.0 branch (=without this fix)
https://user-images.githubusercontent.com/6605505/125475678-2a4ccee1-00e6-460d-8c92-b42d4dab2280.mov



<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
