### PR TITLE
fix: Fixes #219 (editing a story causes a full reload of the app)

### DIFF
--- a/app/react-native/src/preview/loadCsf.ts
+++ b/app/react-native/src/preview/loadCsf.ts
@@ -244,5 +244,10 @@ export const loadCsf = ({
       );
     }
 
+    if (m && m.hot) {
+      storyStore.clearGlobalDecorators();
+      m.hot.accept();
+    }
+
     configApi.configure(loadStories(loadable, framework, { clientApi, storyStore }), m);
   };

--- a/app/react-native/src/preview/loadCsf.ts
+++ b/app/react-native/src/preview/loadCsf.ts
@@ -1,5 +1,6 @@
 import { ClientApi, ConfigApi, StoryStore } from '@storybook/client-api';
 import { logger } from '@storybook/client-logger';
+import { FORCE_RE_RENDER } from '@storybook/core-events';
 import { isExportStory, storyNameFromExport, toId } from '@storybook/csf';
 import './global';
 
@@ -247,6 +248,7 @@ export const loadCsf = ({
     if (m && m.hot) {
       storyStore.clearGlobalDecorators();
       m.hot.accept();
+      storyStore._channel.emit(FORCE_RE_RENDER);
     }
 
     configApi.configure(loadStories(loadable, framework, { clientApi, storyStore }), m);


### PR DESCRIPTION
# Note: Breaks fast reloading of storiesOf -format
With this change, editing the `storiesOf`-format stories (e.g. `Button.stories.tsx` under `/examples/native/components/PromiseTest`) starts throwing an error (see screenshot).

Don't know why that happens. Perhaps fast reloading `Button.stories.tsx` causes the `storiesOf(..).add` call to get re-run? Adding a `storyStore.startConfiguring()` call (see https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#story-store-immutable-outside-of-configuration ) prior to `m.hot.accept()` does not help.

![Screen Shot 2021-07-14 at 11 47 18](https://user-images.githubusercontent.com/6605505/125592868-db4ee70e-c58d-4253-a4a4-de49e2be302d.png)


## UX for CSF stories the next-6.0 branch (=without this fix)

https://user-images.githubusercontent.com/6605505/125520359-da2fe881-c503-47b5-b78b-04152ad990aa.mov

## UX for CSF stories this branch

https://user-images.githubusercontent.com/6605505/125580674-10993194-3246-456e-b3e6-557a78ebdc91.mov

Issue: #219 

## What I did
Changed how the CSF stories get reloaded.

Had to use the `FORCE_RE_RENDER` workaround to get fast reload changes to be immediately reflected on the UI.

## How to test
See the steps to reproduce the issue at https://github.com/storybookjs/react-native/issues/219. Basically, edit a CSF story (e.g. `Boolean.stories.tsx`) while the app is running.

- Does this need a new example in examples/native? **no**, not in my opinion
- Does this need an update to the documentation? **no**, not in my opinion

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
