### PR TITLE
fix: Fixes selected story changing when editing the story file

### DIFF
--- a/app/react-native/src/preview/Preview.tsx
+++ b/app/react-native/src/preview/Preview.tsx
@@ -84,11 +84,12 @@ export default class Preview {
       );
     }
 
-    const { initialSelection, shouldPersistSelection } = params;
-    this._setInitialStory(initialSelection, shouldPersistSelection);
     if (params.asyncStorage) {
       this._asyncStorage = params.asyncStorage;
     }
+
+    const { initialSelection, shouldPersistSelection } = params;
+    this._setInitialStory(initialSelection, shouldPersistSelection);
 
     this._channel.on(Events.SET_CURRENT_STORY, (d: { storyId: string }) => {
       this._selectStoryEvent(d);
@@ -169,6 +170,7 @@ export default class Preview {
 
   _selectStory(story: any) {
     this._storyStore.setSelection({ storyId: story.id, viewMode: 'story' });
+    this._channel.emit(Events.SELECT_STORY, story);
   }
 
   _checkStory(storyId: string) {

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -76,16 +76,15 @@ const useSelectedStory = (storyStore: StoryStore) => {
   const channel = useRef(addons.getChannel());
 
   useEffect(() => {
-    const handleStoryWasSet = ({ storyId: newStoryId }: { storyId: string }) =>
-      setStoryId(newStoryId);
+    const handleStoryWasSet = ({ id: newStoryId }: { id: string }) => setStoryId(newStoryId);
 
     const currentChannel = channel.current;
-    channel.current.on(Events.SET_CURRENT_STORY, handleStoryWasSet);
+    channel.current.on(Events.SELECT_STORY, handleStoryWasSet);
     //TODO: update preview without force
     channel.current.on(Events.FORCE_RE_RENDER, forceUpdate);
 
     return () => {
-      currentChannel.removeListener(Events.SET_CURRENT_STORY, handleStoryWasSet);
+      currentChannel.removeListener(Events.SELECT_STORY, handleStoryWasSet);
       currentChannel.removeListener(Events.FORCE_RE_RENDER, forceUpdate);
     };
   }, []);


### PR DESCRIPTION
Issue: #219 

## What I did
Fixed issue that could be repeated with the following steps:

1. Run the React Native examples (under examples/native)
2. Select a story, e.g. "Boolean control - Basic" (Boolean.stories.tsx)
3. Edit that story file (e.g. change the "on" argument to false in Boolean.stories.tsx)

### What happened before this fix
The entire app reloaded and the currently selected story was changed. See video below:

https://user-images.githubusercontent.com/6605505/125652354-07599d01-9c15-42de-9c5d-992193705e2a.mov

### What happens now after the fix
The entire app reloads, but the selected story persists. This improves the developer UX (don't need to always re-select the story after changes).

https://user-images.githubusercontent.com/6605505/125652509-dbba06ab-b599-4c2f-b2ac-55bebaab4065.mov

Unlike PR #222 this also works with stories that are in `storiesOf` format:

https://user-images.githubusercontent.com/6605505/125652694-fb0b313c-8407-4c6d-898e-b143fcfe2aec.mov

## How to test
See example steps under "What I did".

- Does this need a new example in examples/native? **no**, not in my opinion
- Does this need an update to the documentation? **no*', not in my opinion

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
