### PR TITLE
feat: adds a prepareall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dev:js": "echo 'DEPRECATED: Please use yarn dev:babel' && yarn dev:babel",
     "dev:ts": "echo 'DEPRECATED: Please use yarn dev:tsc' && yarn dev:tsc",
     "dev:tsc": "lerna exec --scope @storybook/* --parallel -- cross-env-shell node \\$LERNA_ROOT_PATH/scripts/watch-tsc.js",
+    "prepareAll": "lerna exec --scope @storybook/* --parallel -- cross-env-shell yarn prepare",
     "docs:build": "npm --prefix docs run build",
     "docs:dev": "npm --prefix docs run dev",
     "github-release": "github-release-from-changelog",


### PR DESCRIPTION
Issue: #213 

## What I did

I added a script that you can use to run the prepare command on all packages. This has been useful for when i don't want to run the watcher.

The way I use this is that when I want to test a PR I check out the PR and run 

```
yarn install
yarn prepareAll
cd examples/native/ios
pod install
```

This way everything is ready to test and I just need to run the app.

Open to feedback and ideas!

## How to test

run `yarn prepareAll`
