### PR TITLE
fix: Fixes the "`storyFn` is deprecated and will be removed in Storybook 7.0." deprecation warning 

### DIFF
--- a/app/react-native/src/preview/components/StoryView/StoryView.tsx
+++ b/app/react-native/src/preview/components/StoryView/StoryView.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { StoreItem } from '@storybook/client-api';
 import { Text, View, StyleSheet } from 'react-native';
+import { StoryContext } from '@storybook/addons';
 
 interface Props {
-  story: StoreItem;
+  story?: StoreItem;
 }
 
 const styles = StyleSheet.create({
@@ -19,11 +20,23 @@ const styles = StyleSheet.create({
 });
 
 const StoryView = ({ story }: Props) => {
-  if (story && story.storyFn) {
-    const { id, storyFn } = story;
+  const [context, setContext] = useState<StoryContext | undefined>(undefined);
+  const id = story?.id;
+
+  useEffect(() => {
+    const loadContext = async () => {
+      if (story && story.unboundStoryFn && story.applyLoaders) {
+        setContext(await story.applyLoaders());
+      }
+    };
+    loadContext();
+  }, [story, id]);
+
+  if (story && story.unboundStoryFn) {
+    const { unboundStoryFn } = story;
     return (
       <View key={id} testID={id} style={styles.container}>
-        {storyFn()}
+        {context && context.id === story.id ? unboundStoryFn(context) : null}
       </View>
     );
   }


### PR DESCRIPTION
Fixes the storyFn deprecation warning that was shown when rendering the story. Fix based on the instructions at https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storyfn

![Screen Shot 2021-07-15 at 16 10 57](https://user-images.githubusercontent.com/6605505/125857460-e50bb9b9-f6c8-4cef-93ff-c45d15a7f84b.png)

Issue: (Don't know if there is one; could be 6.0-specific?)

## What I did
Changed `StoryView.tsx` with instructions from https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-storyfn .

## How to test
Experiment with the different example stories in `examples/native`: They should work as previously, just the deprecation warning should be gone.

- Does this need a new example in examples/native? **no**, not in my opinion
- Does this need an update to the documentation? **no**, not in my opinion

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
