### PR TITLE
feat: Reintroduce the backgrounds addon 

### DIFF
--- a/addons/ondevice-backgrounds/README.md
+++ b/addons/ondevice-backgrounds/README.md
@@ -2,8 +2,6 @@
 
 Storybook Backgrounds Addon for react-native can be used to change background colors of your stories right from the device.
 
-<img src="https://raw.githubusercontent.com/storybookjs/storybook/master/addons/ondevice-backgrounds/docs/demo.gif" alt="Storybook Backgrounds Addon Demo" width="400" />
-
 ## Installation
 
 ```sh
@@ -12,41 +10,16 @@ yarn add -D @storybook/addon-ondevice-backgrounds
 
 ## Configuration
 
-Create a file called `rn-addons.js` in your storybook config.
-
-Add following content to it:
+Then, add following content to `.storybook/main.js`:
 
 ```js
-import '@storybook/addon-ondevice-backgrounds/register';
-```
-
-Then import `rn-addons.js` next to your `getStorybookUI` call.
-
-```js
-import './rn-addons';
+module.exports = {
+  addons: ['@storybook/addon-ondevice-backgrounds'],
+};
 ```
 
 ## Usage
 
-react-native users will have to import `storiesOf` from `@storybook/react-native` and are required to add the `withBackgrounds` decorator.
+See the [example of using the Backgrounds addon with Component Story Format](../../examples/native/components/BackgroundExample/BackgroundCsf.stories.tsx). You can also run the [react-native app](../../examples/native) to see it in action.
 
-Then write your stories like this:
-
-```js
-import React from 'react';
-import { storiesOf } from '@storybook/react-native';
-import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
-
-addDecorator(withBackgrounds);
-
-storiesOf('Button', module)
-  .addParameters({
-    backgrounds: [
-      { name: 'dark', value: '#222222' },
-      { name: 'light', value: '#eeeeee', default: true },
-    ],
-  })
-  .add('with text', () => <Text>Click me</Text>);
-```
-
-See [web backgrounds addon](../backgrounds#usage) for detailed usage and the [crna-kitchen-sink app](../../examples/crna-kitchen-sink) for more examples.
+The [web backgrounds addon documentation](https://storybook.js.org/docs/react/essentials/backgrounds) may also be useful, but the examples there have not been tested with React-Native Storybook.

--- a/addons/ondevice-backgrounds/src/BackgroundPanel.tsx
+++ b/addons/ondevice-backgrounds/src/BackgroundPanel.tsx
@@ -10,33 +10,54 @@ import BackgroundEvents, { PARAM_KEY } from './constants';
 import { Background } from './index';
 
 const codeSample = `
-import { storiesOf } from '@storybook/react-native';
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react-native';
 import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
+import { Dimensions, Text, View, StyleSheet } from 'react-native';
 
-addDecorator(withBackgrounds);
+const Background = () => (
+  <View style={styles.view}>
+    <Text style={styles.text}>Change background color via Addons -&gt; Background</Text>
+  </View>
+);
 
-storiesOf('First Component', module)
-  .addParameters({
+const styles = StyleSheet.create({
+  view: { height: Dimensions.get('window').height },
+  text: { color: 'black' },
+});
+
+const BackgroundMeta: ComponentMeta<typeof Background> = {
+  title: 'Background CSF',
+  component: Background,
+  decorators: [withBackgrounds],
+  parameters: {
     backgrounds: [
       { name: 'warm', value: 'hotpink', default: true },
       { name: 'cool', value: 'deepskyblue' },
     ],
-  })
-  .add("First Button", () => <Button>Click me</Button>);
+  },
+};
+
+export default BackgroundMeta;
+
+type BackgroundStory = ComponentStory<typeof Background>;
+
+export const Basic: BackgroundStory = () => <Background />;
 `.trim();
 
 const Instructions = () => (
   <View>
-    <Text style={styles.title}>Setup Instructions</Text>
-    <Text>
+    <Text style={[styles.paragraph, styles.title]}>Setup Instructions</Text>
+    <Text style={styles.paragraph}>
       Please add the background decorator definition to your story. The background decorate accepts
       an array of items, which should include a name for your color (preferably the css class name)
       and the corresponding color / image value.
     </Text>
-    <Text>
-      Below is an example of how to add the background decorator to your story definition.
+    <Text style={styles.paragraph}>
+      Below is an example of how to add the background decorator to your story definition. Long
+      press the example to copy it.
     </Text>
-    <Text>{codeSample}</Text>
+    <Text selectable>{codeSample}</Text>
   </View>
 );
 
@@ -76,9 +97,7 @@ export default class BackgroundPanel extends Component<BackgroundPanelProps, Bac
       return null;
     }
 
-    const story = api
-      .store()
-      .getStoryAndParameters(this.state.selection.kind, this.state.selection.name);
+    const story = api.store().getRawStory(this.state.selection.kind, this.state.selection.name);
     const backgrounds: Background[] = story.parameters[PARAM_KEY];
 
     return (
@@ -99,4 +118,5 @@ export default class BackgroundPanel extends Component<BackgroundPanelProps, Bac
 
 const styles = StyleSheet.create({
   title: { fontSize: 16 },
+  paragraph: { marginBottom: 8 },
 });

--- a/addons/ondevice-backgrounds/src/BackgroundPanel.tsx
+++ b/addons/ondevice-backgrounds/src/BackgroundPanel.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import Events from '@storybook/core-events';
 import { AddonStore } from '@storybook/addons';
 import { API } from '@storybook/api';
 import { StoryStore } from '@storybook/client-api';
@@ -74,30 +73,20 @@ interface BackgroundPanelState {
 }
 
 export default class BackgroundPanel extends Component<BackgroundPanelProps, BackgroundPanelState> {
-  componentDidMount() {
-    this.props.channel.on(Events.SELECT_STORY, this.onStorySelected);
-  }
-
-  componentWillUnmount() {
-    this.props.channel.removeListener(Events.SELECT_STORY, this.onStorySelected);
-  }
-
   setBackgroundFromSwatch = (background: string) => {
     this.props.channel.emit(BackgroundEvents.UPDATE_BACKGROUND, background);
-  };
-
-  onStorySelected = (selection: Selection) => {
-    this.setState({ selection });
   };
 
   render() {
     const { active, api } = this.props;
 
-    if (!active || !this.state) {
+    if (!active) {
       return null;
     }
 
-    const story = api.store().getRawStory(this.state.selection.kind, this.state.selection.name);
+    const store = api.store();
+    const storyId = store.getSelection().storyId;
+    const story = store.fromId(storyId);
     const backgrounds: Background[] = story.parameters[PARAM_KEY];
 
     return (

--- a/addons/ondevice-backgrounds/src/BackgroundPanel.tsx
+++ b/addons/ondevice-backgrounds/src/BackgroundPanel.tsx
@@ -12,16 +12,13 @@ const codeSample = `
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react-native';
 import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
-import { Dimensions, Text, View, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 
 const Background = () => (
-  <View style={styles.view}>
-    <Text style={styles.text}>Change background color via Addons -&gt; Background</Text>
-  </View>
+  <Text style={styles.text}>Change background color via Addons -&gt; Background</Text>
 );
 
 const styles = StyleSheet.create({
-  view: { height: Dimensions.get('window').height },
   text: { color: 'black' },
 });
 

--- a/examples/native/.storybook/main.js
+++ b/examples/native/.storybook/main.js
@@ -3,5 +3,9 @@ module.exports = {
     './components/**/*.stories.?(ts|tsx|js|jsx)',
     './other_components/AnotherButton/AnotherButton.stories.tsx',
   ],
-  addons: ['@storybook/addon-ondevice-notes', '@storybook/addon-ondevice-controls'],
+  addons: [
+    '@storybook/addon-ondevice-notes',
+    '@storybook/addon-ondevice-controls',
+    '@storybook/addon-ondevice-backgrounds',
+  ],
 };

--- a/examples/native/.storybook/preview.js
+++ b/examples/native/.storybook/preview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-// import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
+import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
 
 export const decorators = [
   (StoryFn) => (
@@ -8,8 +8,16 @@ export const decorators = [
       <StoryFn />
     </View>
   ),
+  withBackgrounds,
 ];
-export const parameters = { my_param: 'anything' };
+export const parameters = {
+  my_param: 'anything',
+  backgrounds: [
+    { name: 'plain', value: 'white', default: true },
+    { name: 'warm', value: 'hotpink' },
+    { name: 'cool', value: 'deepskyblue' },
+  ],
+};
 
 const styles = StyleSheet.create({
   container: { padding: 8 },

--- a/examples/native/.storybook/preview.js
+++ b/examples/native/.storybook/preview.js
@@ -20,5 +20,5 @@ export const parameters = {
 };
 
 const styles = StyleSheet.create({
-  container: { padding: 8 },
+  container: { padding: 8, flex: 1 },
 });

--- a/examples/native/components/BackgroundExample/Background.stories.tsx
+++ b/examples/native/components/BackgroundExample/Background.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { addDecorator, storiesOf } from '@storybook/react-native';
+import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
+import { Text } from 'react-native';
+
+// Remember to also include '@storybook/addon-ondevice-backgrounds' in your addons config: see /examples/native/.storybook/main.js
+addDecorator(withBackgrounds);
+
+storiesOf('Background StoriesOf', module)
+  .addParameters({
+    backgrounds: [
+      { name: 'warm', value: 'hotpink', default: true },
+      { name: 'cool', value: 'deepskyblue' },
+    ],
+  })
+  .add('Basic', () => <Text>Change background color via Addons -&gt; Background</Text>);

--- a/examples/native/components/BackgroundExample/BackgroundCsf.stories.tsx
+++ b/examples/native/components/BackgroundExample/BackgroundCsf.stories.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react-native';
 import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
-import { Dimensions, Text, View, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 
 const Background = () => (
-  <View style={styles.view}>
-    <Text style={styles.text}>Change background color via Addons -&gt; Background</Text>
-  </View>
+  <Text style={styles.text}>Change background color via Addons -&gt; Background</Text>
 );
 
 const styles = StyleSheet.create({
-  view: { height: Dimensions.get('window').height },
   text: { color: 'black' },
 });
 

--- a/examples/native/components/BackgroundExample/BackgroundCsf.stories.tsx
+++ b/examples/native/components/BackgroundExample/BackgroundCsf.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react-native';
+import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
+import { Dimensions, Text, View, StyleSheet } from 'react-native';
+
+const Background = () => (
+  <View style={styles.view}>
+    <Text style={styles.text}>Change background color via Addons -&gt; Background</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  view: { height: Dimensions.get('window').height },
+  text: { color: 'black' },
+});
+
+const BackgroundMeta: ComponentMeta<typeof Background> = {
+  title: 'Background CSF',
+  component: Background,
+  decorators: [withBackgrounds],
+  parameters: {
+    backgrounds: [
+      { name: 'warm', value: 'hotpink', default: true },
+      { name: 'cool', value: 'deepskyblue' },
+    ],
+  },
+};
+
+export default BackgroundMeta;
+
+type BackgroundStory = ComponentStory<typeof Background>;
+
+export const Basic: BackgroundStory = () => <Background />;

--- a/examples/native/package.json
+++ b/examples/native/package.json
@@ -32,6 +32,7 @@
     "@react-native-community/slider": "^3.0.3",
     "@storybook/addon-actions": "^6.3.1",
     "@storybook/addon-links": "^6.3.1",
+    "@storybook/addon-ondevice-backgrounds": "^6.0.0-alpha.0",
     "@storybook/addon-ondevice-controls": "^6.0.0-alpha.0",
     "@storybook/addons": "^6.3.1",
     "@storybook/react-native": "^6.0.0-alpha.0",


### PR DESCRIPTION
Issue: #200 (part of the scope of that issue)

## What I did
Reintroduced the backgrounds addon as a part of completing #200. Includes both storiesOf and CSF examples of usage.

## How to test
Run the React Native examples under `examples/native` on the iOS and Android emulators. Experiment with the added examples:

* **Background StoriesOf**: Not sure if we want to keep this, given that **storiesOf** is apparently going away? However, it can be used to demo that this works with existing stories that use the **storiesOf** format.
* **Background CSF**: Same example in the CSF format.

Also check the modified "Backgrounds not configured" text (e.g. open button promise > finally > Addons > Backgrounds).

- Does this need a new example in examples/native? **yes**, added both CSF & StoriesOf examples
- Does this need an update to the documentation? **yes**; did a minor update to the `@storybook/addon-ondevice-backgrounds` README, but we should have much better docs & also confirm/add support for all of the web examples

### Screen recording of functionality

https://user-images.githubusercontent.com/6605505/125938162-3b33027e-5067-41cc-8e18-63b66ec461f1.mp4

### ~~Known issue: Reloading on iOS does not work~~
Edit: Never mind, did some changes in 73e783a2f3467f830c74f7b508e31f44952c93dd to fix this.
~~Reloading the app (e.g. via the emulator or due to making changes) causes the controls in "Addons => Backgrounds" to disappear on iOS. It works correctly on Android. Don't know what is causing this. Any help in fixing is appreciated. See recording below:~~

https://user-images.githubusercontent.com/6605505/125938242-6f94e413-1d9d-4938-b006-ac7f220507e6.mov



<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
