### PR TITLE
docs: Start of addon-ondevice-controls README + minor tweaks to addon-ondevice-backgrounds README

### DIFF
--- a/addons/ondevice-backgrounds/README.md
+++ b/addons/ondevice-backgrounds/README.md
@@ -1,11 +1,11 @@
-# Storybook Backgrounds Addon for react-native
+# Storybook Backgrounds Addon for React Native
 
-Storybook Backgrounds Addon for react-native can be used to change background colors of your stories right from the device.
+Storybook Backgrounds Addon for React Native can be used to change background colors of your stories right from the device.
 
 ## Installation
 
 ```sh
-yarn add -D @storybook/addon-ondevice-backgrounds
+yarn add -D @storybook/addon-ondevice-backgrounds @storybook/addons
 ```
 
 ## Configuration
@@ -20,6 +20,6 @@ module.exports = {
 
 ## Usage
 
-See the [example of using the Backgrounds addon with Component Story Format](../../examples/native/components/BackgroundExample/BackgroundCsf.stories.tsx). You can also run the [react-native app](../../examples/native) to see it in action.
+See the [example of using the Backgrounds Addon with Component Story Format](../../examples/native/components/BackgroundExample/BackgroundCsf.stories.tsx). You can also run the [react-native app](../../examples/native) to see it in action.
 
-The [web backgrounds addon documentation](https://storybook.js.org/docs/react/essentials/backgrounds) may also be useful, but the examples there have not been tested with React-Native Storybook.
+The [web Backgrounds Addon documentation](https://storybook.js.org/docs/react/essentials/backgrounds) may also be useful, but the examples there have not been tested with Storybook for React Native.

--- a/addons/ondevice-controls/README.md
+++ b/addons/ondevice-controls/README.md
@@ -1,32 +1,27 @@
-# Storybook Knobs Addon for react-native
+# Storybook Controls Addon for React Native
 
-Storybook Knobs Addon allows you to edit react props using the Storybook UI using variables inside stories in [Storybook](https://storybook.js.org).
-
-[Framework Support](https://github.com/storybookjs/storybook/blob/master/ADDONS_SUPPORT.md)
-
-**This is a wrapper for the addon [@storybook/addon-knobs](https://github.com/storybookjs/storybook/blob/master/addons/knobs).
-Refer to its documentation to understand how to use knobs**
+Storybook Controls Addon for React Native allows editing a component's arguments dynamically via a graphical UI without needing to code. The Controls Addon replaces the old Knobs Addon.
 
 ## Installation
 
 ```sh
-yarn add -D @storybook/addon-ondevice-knobs @storybook/addon-knobs
+yarn add -D @storybook/addon-ondevice-controls @storybook/addons
 ```
 
 ## Configuration
 
-Create a file called `rn-addons.js` in your storybook config.
-
-Add following content to it:
+Then, add following content to `.storybook/main.js`:
 
 ```js
-import '@storybook/addon-ondevice-knobs/register';
+module.exports = {
+  addons: ['@storybook/addon-ondevice-controls'],
+};
 ```
 
-Then import `rn-addons.js` next to your `getStorybookUI` call.
+See the [examples of using the Controls Addon with Component Story Format](../../examples/native/components/ControlExamples). You can also run the [react-native app](../../examples/native) to see it in action.
 
-```js
-import './rn-addons';
-```
+The [web Controls Addon documentation](https://storybook.js.org/docs/react/essentials/controls) may also be useful, but the examples there have not been tested with Storybook for React Native.
 
-See [@storybook/addon-knobs](https://github.com/storybookjs/storybook/blob/master/addons/knobs) to learn how to write stories with knobs and the [crna-kitchen-sink app](../../examples/crna-kitchen-sink) for more examples.
+## Migrating from Knobs
+
+See [examples for migrating from Knobs to Controls](https://github.com/storybookjs/storybook/tree/next/addons/controls#how-do-i-migrate-from-addon-knobs) in the web Controls Addon README.


### PR DESCRIPTION
Issue: #202

## What I did
First minor steps towards a `addon-ondevice-controls` README. Also tweaked the `addon-ondevice-backgrounds` README a bit.

This is just the first nibble at this issue; we'll need to revamp the READMEs quite a bit, especially the main README.

## How to test
Check the accuracy of the docs to the best of your knowledge. Haven't set up a V6 Alpha 1 project from scratch yet. I guess we could try this already (the `examples/native` project works fine with the local 6.0.0-alpha.0 deps, so setting up `example/foobar` to write & validate docs should work as well?).

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
