### PR TITLE
fix: better example for select control

### DIFF
--- a/addons/ondevice-controls/src/types/Select.tsx
+++ b/addons/ondevice-controls/src/types/Select.tsx
@@ -24,7 +24,6 @@ export interface SelectProps {
   onChange: (value: any) => void;
 }
 
-//TODO: mapping
 const getOptions = ({ options, control: { labels } }: SelectProps['arg']) => {
   if (Array.isArray(options)) {
     if (labels) {

--- a/examples/native/components/ControlExamples/Select/Select.stories.tsx
+++ b/examples/native/components/ControlExamples/Select/Select.stories.tsx
@@ -16,7 +16,7 @@ const SelectExampleMeta: ComponentMeta<typeof SelectExample> = {
     },
   },
   parameters: {
-    notes: 'currently mapping is not working.',
+    notes: 'Select from mulitple options!',
   },
 };
 

--- a/examples/native/components/ControlExamples/Select/Select.stories.tsx
+++ b/examples/native/components/ControlExamples/Select/Select.stories.tsx
@@ -2,18 +2,14 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react-native';
 import { SelectExample } from './Select';
 
-const ArrowUp = '⬆';
-const ArrowDown = '⬇';
-const ArrowLeft = '⬅️';
-const ArrowRight = '➡️';
-const arrows = { ArrowUp, ArrowDown, ArrowLeft, ArrowRight };
+const arrows = { ArrowUp: '⬆', ArrowDown: '⬇', ArrowLeft: '⬅️', ArrowRight: '➡️' };
 
 const SelectExampleMeta: ComponentMeta<typeof SelectExample> = {
   title: 'Select control',
   component: SelectExample,
   argTypes: {
     arrow: {
-      options: [ArrowUp, ArrowDown, ArrowLeft, ArrowRight],
+      options: Object.values(arrows),
       control: {
         type: 'select',
       },
@@ -31,7 +27,7 @@ type SelectExampleStory = ComponentStory<typeof SelectExample>;
 export const Basic: SelectExampleStory = (args) => <SelectExample {...args} />;
 
 Basic.args = {
-  arrow: ArrowLeft,
+  arrow: arrows.ArrowLeft,
 };
 
 export const WithLabels: SelectExampleStory = (args) => <SelectExample {...args} />;
@@ -46,13 +42,33 @@ WithLabels.argTypes = {
     control: {
       type: 'select',
       labels: {
-        [ArrowUp]: 'Up',
-        [ArrowDown]: 'Down',
-        [ArrowLeft]: 'Left',
-        [ArrowRight]: 'Right',
+        [arrows.ArrowUp]: 'Up',
+        [arrows.ArrowDown]: 'Down',
+        [arrows.ArrowLeft]: 'Left',
+        [arrows.ArrowRight]: 'Right',
       },
     },
   },
 };
 
-//TODO: mapping
+export const WithMapping: SelectExampleStory = (args) => <SelectExample {...args} />;
+
+WithMapping.args = {
+  arrow: 'ArrowUp',
+};
+
+WithMapping.argTypes = {
+  arrow: {
+    options: Object.keys(arrows),
+    mapping: arrows,
+    control: {
+      type: 'select',
+      labels: {
+        ArrowUp: 'Up',
+        ArrowDown: 'Down',
+        ArrowLeft: 'Left',
+        ArrowRight: 'Right',
+      },
+    },
+  },
+};


### PR DESCRIPTION
Issue: #214 

## What I did

Turns out mappings are working however I had understood it a bit incorrectly. I've updated the example to show this.

## How to test

1. run the example app
2. choose the select control story with mappers
3. change the selected arrow with the control in addon panel