### PR TITLE
fix: Fixes #237 by adding util dependency 

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -48,7 +48,8 @@
     "chokidar": "^3.5.1",
     "emotion-theming": "^10.0.19",
     "glob": "^7.1.7",
-    "react-native-swipe-gestures": "^1.0.5"
+    "react-native-swipe-gestures": "^1.0.5",
+    "util": "^0.12.4"
   },
   "devDependencies": {
     "@types/react-native": "^0.64.6"


### PR DESCRIPTION
(util-deprecate should come transitively, we shouldn't need a direct dependency)

Issue: #237 

## What I did
Added the missing dependency.

## How to test
Test with the steps at https://github.com/storybookjs/react-native/blob/next-6.0/v6README.md , just omit adding the `util` and `util-deprecate`-dependencies

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
