### PR TITLE
docs: Remove the need to install util and util-deprecate from the v6README (works without them)

### DIFF
--- a/v6README.md
+++ b/v6README.md
@@ -21,7 +21,6 @@ Open up your react native project in your chosen editor, here I use vscode
 code .
 ```
 
-
 Now install the react native storybook dependencies, here I'm installing all the available ondevice addons. You can just pick the addons you want to use.
 
 ```shell
@@ -34,8 +33,7 @@ yarn add @storybook/react-native@next \
             @storybook/addon-actions \
             @react-native-community/datetimepicker \
             @react-native-community/slider \
-            @storybook/addon-controls \
-            util util-deprecate
+            @storybook/addon-controls
 ```
 
 Datetime picker, slider and addon-controls are required for controls to work. If you don't want controls you don't need to install these (controls is the knobs replacement).
@@ -132,6 +130,7 @@ fs.writeFile("./package.json", JSON.stringify(packageJSON, null, 2), function wr
 ```
 
 If you're on macos then run pod install
+
 ```shell
 cd ios; pod install; cd ..;
 ```
@@ -190,10 +189,8 @@ export const Basic: MyButtonStory = args => <MyButton {...args} />;
 " > components/Button/Button.stories.tsx
 ```
 
-
-
-
 Run the stories auto detection which uses main.js to detect stories.
+
 ```shell
 yarn sbn-get-stories
 ```


### PR DESCRIPTION
Issue: #237 

## What I did.
Confirmed that `util` and `util-deprecate` no longer need to be added as dependencies with alpha.1, so removed those from the v6README. **Note**: https://gist.github.com/dannyhw/9b84973dcc6ff4fa2e86e32d571d294e should also be edited accordingly.

## How to test
Repeat the steps in the v6README and confirm that the project works.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
