### PR TITLE
fix: Fixes #242 (an action appears in the controls tab as an invalid control type)

### DIFF
--- a/addons/ondevice-controls/src/ControlsPanel.tsx
+++ b/addons/ondevice-controls/src/ControlsPanel.tsx
@@ -48,19 +48,19 @@ const ControlsPanel = ({ api }: { api: API }) => {
   const storyId = store.getSelection().storyId;
   const [argsfromHook, updateArgs, resetArgs] = useArgs(storyId, store);
   const { argTypes, parameters } = store.fromId(storyId);
+  const argsObject = Object.entries(argsfromHook).reduce((prev, [name, value]) => {
+    const isControl = Boolean(argTypes?.[name]?.control);
 
-  const isArgsStory = parameters.__isArgsStory;
-
-  const hasControls = Object.values(argTypes).some((arg: ArgType) => arg?.control);
-  const showWarning = !(hasControls && isArgsStory);
-  const argsObject = hasControls
-    ? Object.entries(argsfromHook).reduce((prev, [name, value]) => {
-        return {
+    return isControl
+      ? {
           ...prev,
           [name]: { ...argTypes?.[name], name, type: argTypes[name]?.control?.type, value },
-        };
-      }, {})
-    : {};
+        }
+      : prev;
+  }, {});
+  const hasControls = Object.keys(argsObject).length > 0;
+  const isArgsStory = parameters.__isArgsStory;
+  const showWarning = !(hasControls && isArgsStory);
 
   return (
     <>

--- a/examples/native/components/ActionExample/Actions.stories.tsx
+++ b/examples/native/components/ActionExample/Actions.stories.tsx
@@ -8,6 +8,9 @@ const ActionButtonMeta: ComponentMeta<typeof ActionButton> = {
   argTypes: {
     onPress: { action: 'pressed the button' },
   },
+  args: {
+    text: 'Press me!',
+  },
 };
 export default ActionButtonMeta;
 

--- a/examples/native/components/ActionExample/Actions.tsx
+++ b/examples/native/components/ActionExample/Actions.tsx
@@ -3,12 +3,13 @@ import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 
 interface ActionButtonProps {
   onPress: () => void;
+  text: string;
 }
 
-export const ActionButton = ({ onPress }: ActionButtonProps) => {
+export const ActionButton = ({ onPress, text }: ActionButtonProps) => {
   return (
     <TouchableOpacity style={styles.container} onPress={onPress}>
-      <Text style={styles.text}>ActionButton</Text>
+      <Text style={styles.text}>{text}</Text>
     </TouchableOpacity>
   );
 };


### PR DESCRIPTION
Issue: #242 

## What I did
In the controls panel, filter out the non-control args so that e.g. actions do not incorrectly get shown in the controls tab.

## How to test
Use the ActionButton -> Basic example in the example app under `/examples/native`:

### Run it with the changes in this branch as-is
The Controls tab shows the control and does not (incorrectly) show the action:

https://user-images.githubusercontent.com/6605505/127328653-fe766267-cbd9-48a9-bf16-0b9a841af794.mov

### Run it without the changes in ControlsPanel.tsx
The Controls tab shows both the control and (incorrectly) the action:

https://user-images.githubusercontent.com/6605505/127329774-8fa04960-1c12-416a-b680-4f7e0e9997e5.mov

- Does this need a new example in examples/native? **no**, in my opinion adjusting the existing example (as is done here) is sufficient
- Does this need an update to the documentation? **no**, not in my opinion

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
