### PR TITLE
docs: Fixes #247 by editing the v6 alpha guide with instructions on how to set up with Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 With Storybook for React Native you can design and develop individual React Native components without running your app.
 
-This readme will be used for 6.0 documentation going forward, [find the 5.3 readme here ](https://github.com/storybookjs/react-native/tree/v5.3.25#readme)
+This readme will be used for 6.0 documentation going forward, [find the 5.3 readme here](https://github.com/storybookjs/react-native/tree/v5.3.25#readme)
 
 The first 6.0 alpha is out now `6.0.1-alpha.0` to try it out follow [this guide](https://github.com/storybookjs/react-native/blob/next-6.0/v6README.md) (work in progress)
 

--- a/v6README.md
+++ b/v6README.md
@@ -22,8 +22,7 @@ cd RnSBSixAlpha
 
 ```shell
 npm install --global expo-cli
-expo init appName
-# select blank TypeScript template when prompted
+expo init -t expo-template-blank-typescript appName
 cd appName
 ```
 
@@ -50,8 +49,10 @@ yarn add @storybook/react-native@next \
 
 Datetime picker, slider and addon-controls are required for controls to work. If you don't want controls you don't need to install these (controls is the knobs replacement).
 
-For React Native without Expo, update your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'main']}`.
-This enables us to use the modern build of storybook instead of the polyfilled versions. **Skip this step if using Expo, otherwise the app will not work. See [#247](https://github.com/storybookjs/react-native/issues/247).**
+Continue by updating your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'main']}`.
+This enables us to use the modern build of storybook instead of the polyfilled versions.
+
+**Vanilla React Native**
 
 ```shell
 echo "/**
@@ -74,7 +75,27 @@ module.exports = {
     resolverMainFields: ['sbmodern', 'main'],
   },
 };" > metro.config.js
+```
 
+**Expo**
+
+```shell
+echo "const { getDefaultConfig } = require('expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+defaultConfig.resolver.resolverMainFields = [
+  'sbmodern',
+  ...defaultConfig.resolver.resolverMainFields,
+];
+defaultConfig.transformer.getTransformOptions = async () => ({
+  transform: {
+    experimentalImportSupport: false,
+    inlineRequires: false,
+  },
+});
+module.exports = defaultConfig;
+" > metro.config.js;
 ```
 
 Create .storybook/main and preview.js, here we use unix commands to set this up. If you are using windows then just make the .storybook folder and components folder then add the content for main.js and preview.js from those "echo '...' >" commands

--- a/v6README.md
+++ b/v6README.md
@@ -2,20 +2,32 @@
 
 ## Setting up a new project from scratch
 
-I've made a script version of this [here](https://gist.github.com/dannyhw/9b84973dcc6ff4fa2e86e32d571d294e)
+**Vanilla React Native:** Run the [setup script](https://gist.github.com/dannyhw/9b84973dcc6ff4fa2e86e32d571d294e) or follow this guide to do it step-by-step.
 
-For this guide I will assume that you have yarn, node, npm and npx and they are in your path so your
-terminal can run them. These steps also assume mac or linux so if you're on windows you might need
-to do a bit more work. Happy to accept contributions for a windows guide though!
+**Expo:** Follow this guide.
 
-First create a react native project
+This guide assumes that you have yarn, node, npm and npx and they are in your path so your
+terminal can run them. The guide is for Mac/Linux, Windows might need slight adjustments. Contributions for a Windows guide are welcome!
+
+First, create the project:
+
+**Vanilla React Native**
 
 ```shell
 npx react-native init RnSBSixAlpha --template react-native-template-typescript
 cd RnSBSixAlpha
 ```
 
-Open up your react native project in your chosen editor, here I use vscode
+**Expo**
+
+```shell
+npm install --global expo-cli
+expo init appName
+# select blank TypeScript template when prompted
+cd appName
+```
+
+Next, open the project in your chosen editor, here I use vscode
 
 ```shell
 code .
@@ -38,10 +50,8 @@ yarn add @storybook/react-native@next \
 
 Datetime picker, slider and addon-controls are required for controls to work. If you don't want controls you don't need to install these (controls is the knobs replacement).
 
-Currently there is an issue where util and util deprecate are required, this is a dependency issue and will be fixed in the next alpha
-
-Update your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'main']}`.
-This enables us to use the modern build of storybook instead of the polyfilled versions
+For React Native without Expo, update your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'main']}`.
+This enables us to use the modern build of storybook instead of the polyfilled versions. **Skip this step if using Expo, otherwise the app will not work. See [#247](https://github.com/storybookjs/react-native/issues/247).**
 
 ```shell
 echo "/**
@@ -129,7 +139,7 @@ fs.writeFile("./package.json", JSON.stringify(packageJSON, null, 2), function wr
 });';
 ```
 
-If you're on macos then run pod install
+If you're using macOS and vanilla React Native, run pod install:
 
 ```shell
 cd ios; pod install; cd ..;


### PR DESCRIPTION
Also fixes linter warning in README.md.

Issue: #247 

## What I did
Slightly modified the v6 alpha guide so that 6.0 alpha can also be set up on Expo. Notice that there still seem to be some issues with Expo (e.g. the React Native hooks, see https://github.com/storybookjs/react-native/issues/247#issuecomment-897124231)

## How to test
Test the modified v6 alpha guide to ensure that it is understandable & produces a working setup on Expo (and on vanilla React Native, if the user so chooses).

- Does this need a new example in examples/native? **no**, not in my opinion, but we could consider adding an example Expo  project to the repo alongside the vanilla React Native project?
- Does this need an update to the documentation? **included**

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
