### PR TITLE
fix: Fixes #253. Improve the message shown on the Controls tab when the story has no controls configured

### DIFF
--- a/addons/ondevice-controls/src/ControlsPanel.tsx
+++ b/addons/ondevice-controls/src/ControlsPanel.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/native';
 import { API } from '@storybook/api';
 import React from 'react';
-import { Linking, Text } from 'react-native';
 import { useArgs } from './hooks';
+import NoControlsWarning from './NoControlsWarning';
 import PropForm from './PropForm';
 
 const Touchable = styled.TouchableOpacity(({ theme }) => ({
@@ -62,20 +62,12 @@ const ControlsPanel = ({ api }: { api: API }) => {
   const isArgsStory = parameters.__isArgsStory;
   const showWarning = !(hasControls && isArgsStory);
 
+  if (showWarning) {
+    return <NoControlsWarning />;
+  }
+
   return (
     <>
-      {showWarning && (
-        <Text>
-          This story is not configured to handle controls
-          <Text
-            onPress={() =>
-              Linking.openURL('https://storybook.js.org/docs/react/essentials/controls')
-            }
-          >
-            Learn how to add controls
-          </Text>
-        </Text>
-      )}
       <PropForm args={argsObject} onFieldChange={updateArgs} />
       <Touchable onPress={() => resetArgs()}>
         <ResetButton>RESET</ResetButton>

--- a/addons/ondevice-controls/src/NoControlsWarning.tsx
+++ b/addons/ondevice-controls/src/NoControlsWarning.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/native';
+import React from 'react';
+import { Linking, View } from 'react-native';
+
+const Paragraph = styled.Text(() => ({
+  marginBottom: 10,
+}));
+const LinkText = styled.Text(() => ({
+  color: 'blue',
+}));
+
+const NoControlsWarning = () => {
+  return (
+    <View>
+      <Paragraph>This story is not configured to handle controls.</Paragraph>
+      <Paragraph>
+        <LinkText
+          onPress={() => Linking.openURL('https://storybook.js.org/docs/react/essentials/controls')}
+        >
+          Learn how to add controls
+        </LinkText>{' '}
+        and see{' '}
+        <LinkText
+          onPress={() =>
+            Linking.openURL(
+              'https://github.com/storybookjs/react-native/tree/next-6.0/examples/native/components/ControlExamples'
+            )
+          }
+        >
+          examples in the Storybook React Native repository.
+        </LinkText>
+      </Paragraph>
+    </View>
+  );
+};
+
+export default NoControlsWarning;


### PR DESCRIPTION
Issue: #253

## What I did
Improved the message shown on the Controls tab when the story has no controls configured. Here's a screenshot of the new message on iOS & Android:

![Screen Shot 2021-08-15 at 18 37 33](https://user-images.githubusercontent.com/6605505/129484507-510ea9e8-f092-4810-b1ff-bd865b5eed2f.png)

## How to test
Run the example app under `examples/native`. Open the first example (Background StoriesOf => Basic) and look at the message shown on the Controls tab.

- Does this need a new example in examples/native? **no**, not in my opinion
- Does this need an update to the documentation? **no**, not in my opinion

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
