### PR TITLE
docs: Update resolverMainFields for vanilla React Native

### DIFF
--- a/examples/native/metro.config.js
+++ b/examples/native/metro.config.js
@@ -17,6 +17,6 @@ module.exports = {
     }),
   },
   resolver: {
-    resolverMainFields: ['sbmodern', 'main'],
+    resolverMainFields: ['sbmodern', 'browser', 'main'],
   },
 };

--- a/v6README.md
+++ b/v6README.md
@@ -49,7 +49,7 @@ yarn add @storybook/react-native@next \
 
 Datetime picker, slider and addon-controls are required for controls to work. If you don't want controls you don't need to install these (controls is the knobs replacement).
 
-Continue by updating your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'main']}`.
+Continue by updating your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'browser', 'main']}`.
 This enables us to use the modern build of storybook instead of the polyfilled versions.
 
 **Vanilla React Native**
@@ -72,7 +72,7 @@ module.exports = {
     }),
   },
   resolver: {
-    resolverMainFields: ['sbmodern', 'main'],
+    resolverMainFields: ['sbmodern', 'browser', 'main'],
   },
 };" > metro.config.js
 ```


### PR DESCRIPTION
Issue: #255 

## What I did

Add "browser" to the `mainResolverFields`, so as not to break polyfills that depend on it.

An alternative approach would be to override the default config's `mainResolverFields`, but this requires a much bigger change, that I assume some teams may not be comfortable with. Since the default for pretty much all React Native apps should be the same, I think just adding "browser" is a much less invasive change. If a team has customized their `mainResolverFields` already, then it should be pretty clear what they need to do, when updating their `metro.config.js`. Just for reference, below is the altnerative solution:

```ts
const {getDefaultConfig} = require('metro-config');

module.exports = (async () => {
  const {
    resolver: {resolverMainFields},
  } = await getDefaultConfig();
  return {
    transformer: {
      getTransformOptions: async () => ({
        transform: {
          experimentalImportSupport: false,
          inlineRequires: false,
        },
      }),
    },
    resolver: {
      resolverMainFields: ['sbmodern', ...resolverMainFields],
    },
  };
})();
```

## How to test

Run through the v6 instructions, everything should still work same as before.

- Does this need a new example in examples/native? **no**, I did update the existing example though.
- Does this need an update to the documentation? **included**
