### PR TITLE
docs: change v6 test readme to use expo install

### DIFF
--- a/v6README.md
+++ b/v6README.md
@@ -34,6 +34,25 @@ code .
 
 Now install the react native storybook dependencies, here I'm installing all the available ondevice addons. You can just pick the addons you want to use.
 
+**Vanilla React Native**
+
+```shell
+yarn add @storybook/react-native@next \
+            @react-native-async-storage/async-storage \
+            @storybook/addon-ondevice-actions@next \
+            @storybook/addon-ondevice-controls@next \
+            @storybook/addon-ondevice-backgrounds@next \
+            @storybook/addon-ondevice-notes@next \
+            @storybook/addon-actions \
+            @react-native-community/datetimepicker \
+            @react-native-community/slider \
+            @storybook/addon-controls
+```
+
+**Expo**
+
+For Expo, we need to separately install the react native packages so Expo can maintain the compatibility for us.
+
 ```shell
 yarn add @storybook/react-native@next \
             @storybook/addon-ondevice-actions@next \

--- a/v6README.md
+++ b/v6README.md
@@ -36,15 +36,14 @@ Now install the react native storybook dependencies, here I'm installing all the
 
 ```shell
 yarn add @storybook/react-native@next \
-            @react-native-async-storage/async-storage \
             @storybook/addon-ondevice-actions@next \
             @storybook/addon-ondevice-controls@next \
             @storybook/addon-ondevice-backgrounds@next \
             @storybook/addon-ondevice-notes@next \
             @storybook/addon-actions \
-            @react-native-community/datetimepicker \
-            @react-native-community/slider \
             @storybook/addon-controls
+            
+expo install @react-native-async-storage/async-storage @react-native-community/datetimepicker @react-native-community/slider
 ```
 
 Datetime picker, slider and addon-controls are required for controls to work. If you don't want controls you don't need to install these (controls is the knobs replacement).


### PR DESCRIPTION
Issue: Expo warning while following v6 test readme

## What I did

- Change documentation for v6 test readme. Previously, there was a warning 

```
Some dependencies are incompatible with the installed expo package version:
- @react-native-community/slider - expected version: 3.0.3 - actual version installed: 4.1.3
Your project may not work correctly until you install the correct versions of the packages.
To install the correct versions of these packages, please run: expo install [package-name ...]
```

This is caused by not using `expo install` to install `@react-native-community/slider` and maintain compatibility versions. I updated documentation to use `expo install` instead of `yarn add` to maintain compatibility with expo.

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native? No
- Does this need an update to the documentation? This is an documentation update.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
