### PR TITLE
fix(scripts): reduce watcher updates and fix small path bug

### DIFF
--- a/app/react-native/scripts/watcher.js
+++ b/app/react-native/scripts/watcher.js
@@ -10,12 +10,20 @@ const {
 
 const log = console.log.bind(console);
 
-const watchPaths = [...getGlobs(), getMainPath()];
+const watchPaths = [getMainPath()];
 if (getPreviewExists()) {
   watchPaths.push(getPreviewPath());
 }
 
-chokidar.watch(watchPaths).on('all', (event, watchPath) => {
-  log(`event ${event} for file ${path.basename(watchPath)}`);
+const updateRequires = (event, watchPath) => {
+  if (typeof watchPath === 'string') {
+    log(`event ${event} for file ${path.basename(watchPath)}`);
+  }
   writeRequires();
-});
+};
+
+chokidar.watch(watchPaths).on('change', (watchPath) => updateRequires('change', watchPath));
+chokidar
+  .watch(getGlobs())
+  .on('add', (watchPath) => updateRequires('add', watchPath))
+  .on('unlink', (watchPath) => updateRequires('unlink', watchPath));

--- a/examples/native/.storybook/main.js
+++ b/examples/native/.storybook/main.js
@@ -1,7 +1,7 @@
 module.exports = {
   stories: [
-    './components/**/*.stories.?(ts|tsx|js|jsx)',
-    './other_components/AnotherButton/AnotherButton.stories.tsx',
+    'components/**/*.stories.?(ts|tsx|js|jsx)',
+    'other_components/AnotherButton/AnotherButton.stories.tsx',
   ],
   addons: [
     '@storybook/addon-ondevice-notes',

--- a/v6README.md
+++ b/v6README.md
@@ -61,7 +61,7 @@ yarn add @storybook/react-native@next \
             @storybook/addon-ondevice-notes@next \
             @storybook/addon-actions \
             @storybook/addon-controls
-            
+
 expo install @react-native-async-storage/async-storage @react-native-community/datetimepicker @react-native-community/slider
 ```
 
@@ -123,7 +123,7 @@ mkdir .storybook
 mkdir components
 echo "module.exports = {
   stories: [
-    './components/**/*.stories.?(ts|tsx|js|jsx)'
+    'components/**/*.stories.?(ts|tsx|js|jsx)'
   ],
    addons: [
     '@storybook/addon-ondevice-notes',


### PR DESCRIPTION
Issue: NA

## What I did

I've made the watcher only update requires when stories are added or removed or the main/preview.js was updated.

I also made an adjustment to how the paths work in the get-stories script.

## How to test

Run the sbn-watcher and sbn-get-stories scripts in the example project.


<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
