### PR TITLE
fix: make it easier to provide the initial selection

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -55,6 +55,7 @@
     "@types/react-native": "^0.65.1"
   },
   "peerDependencies": {
+    "@react-native-async-storage/async-storage": ">=1",
     "react": "*",
     "react-native": ">=0.57.0"
   },

--- a/examples/native/.storybook/Storybook.tsx
+++ b/examples/native/.storybook/Storybook.tsx
@@ -1,10 +1,10 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getStorybookUI } from '@storybook/react-native';
 
 import './storybook.requires';
 
 const StorybookUIRoot = getStorybookUI({
-  asyncStorage: AsyncStorage,
+  // initialSelection: { kind: 'Radio control', name: 'Basic' },
+  // shouldPersistSelection: false,
 });
 
 export default StorybookUIRoot;


### PR DESCRIPTION
Issue: closes #161 

## What I did

I've made the initial selection parameter an object with kind and name that will be used to figure out the id.

I also made async storage a peer dependency since it's something I've been meaning to do for a while.

## How to test

run the example and uncomment line 6 and 7 in `examples/native/.storybook/Storybook.tsx`

the radio control story should appear first.
