### PR TITLE
styles: improving object control for web

### DIFF
--- a/addons/ondevice-controls/src/types/Object.tsx
+++ b/addons/ondevice-controls/src/types/Object.tsx
@@ -18,6 +18,7 @@ const Input = styled.TextInput(({ theme }) => ({
   margin: 10,
   borderColor: theme.borderColor || '#e6e6e6',
   color: theme.labelColor || 'black',
+  minHeight: 60,
 }));
 
 const ObjectType = ({ arg, onChange }: ObjectProps) => {


### PR DESCRIPTION
Issue: Closes #282 

## What I did
Added styling to display object control in a more editable way.

<img width="395" alt="Screen Shot 2021-11-13 at 1 15 14 a m" src="https://user-images.githubusercontent.com/7416811/141609900-35a3e96a-db1e-46fc-b1b4-c5c3af228281.png">


## How to test
1. `cd examples/native`
2. `yarn web`
3. Open Object control