### PR TITLE
fix: wide screen ui scales better

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -39,7 +39,7 @@ const IS_IOS = Platform.OS === 'ios';
 const getExpoRoot = () => global.Expo || global.__expo || global.__exponent;
 export const IS_EXPO = getExpoRoot() !== undefined;
 const IS_ANDROID = Platform.OS === 'android';
-
+const BREAKPOINT = 1024;
 interface OnDeviceUIProps {
   storyStore: StoryStore;
   url?: string;
@@ -108,7 +108,7 @@ const OnDeviceUI = ({
   });
   const story = useSelectedStory(storyStore);
   const animatedValue = useRef(new Animated.Value(tabOpen));
-  const wide = useWindowDimensions().width >= 1024;
+  const wide = useWindowDimensions().width >= BREAKPOINT;
 
   const handleToggleTab = (newTabOpen: number) => {
     if (newTabOpen === tabOpen) {

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -31,6 +31,7 @@ import {
 import Navigation from './navigation';
 import { PREVIEW, ADDONS } from './navigation/constants';
 import Panel from './Panel';
+import { useWindowDimensions } from 'react-native';
 
 const ANIMATION_DURATION = 300;
 const IS_IOS = Platform.OS === 'ios';
@@ -107,6 +108,7 @@ const OnDeviceUI = ({
   });
   const story = useSelectedStory(storyStore);
   const animatedValue = useRef(new Animated.Value(tabOpen));
+  const wide = useWindowDimensions().width >= 1024;
 
   const handleToggleTab = (newTabOpen: number) => {
     if (newTabOpen === tabOpen) {
@@ -129,10 +131,10 @@ const OnDeviceUI = ({
 
   const previewWrapperStyles = [
     flex,
-    getPreviewPosition(animatedValue.current, previewDimensions, slideBetweenAnimation),
+    getPreviewPosition(animatedValue.current, previewDimensions, slideBetweenAnimation, wide),
   ];
 
-  const previewStyles = [flex, getPreviewScale(animatedValue.current, slideBetweenAnimation)];
+  const previewStyles = [flex, getPreviewScale(animatedValue.current, slideBetweenAnimation, wide)];
 
   return (
     <SafeAreaView style={[flex, IS_ANDROID && IS_EXPO && styles.expoAndroidContainer]}>
@@ -159,10 +161,14 @@ const OnDeviceUI = ({
               ) : null}
             </Animated.View>
           </Animated.View>
-          <Panel style={getNavigatorPanelPosition(animatedValue.current, previewDimensions.width)}>
+          <Panel
+            style={getNavigatorPanelPosition(animatedValue.current, previewDimensions.width, wide)}
+          >
             <StoryListView storyStore={storyStore} selectedStory={story} />
           </Panel>
-          <Panel style={getAddonPanelPosition(animatedValue.current, previewDimensions.width)}>
+          <Panel
+            style={getAddonPanelPosition(animatedValue.current, previewDimensions.width, wide)}
+          >
             <Addons active={tabOpen === ADDONS} />
           </Panel>
         </AbsolutePositionedKeyboardAwareView>

--- a/app/react-native/src/preview/components/OnDeviceUI/animation.ts
+++ b/app/react-native/src/preview/components/OnDeviceUI/animation.ts
@@ -4,10 +4,13 @@ import { NAVIGATOR, PREVIEW, ADDONS } from './navigation/constants';
 
 const PREVIEW_SCALE = 0.3;
 const PREVIEW_WIDE_SCREEN = 0.7;
+const SCALE_OFFSET = 0.025;
+const TRANSLATE_X_OFFSET = 6;
+const TRANSLATE_Y_OFFSET = 12;
 
 const panelWidth = (width: number, wide: boolean) => {
   const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
-  return width * (1 - scale - 0.025);
+  return width * (1 - scale - SCALE_OFFSET);
 };
 
 export const getNavigatorPanelPosition = (
@@ -57,8 +60,8 @@ export const getPreviewPosition = (
   wide: boolean
 ) => {
   const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
-  const translateX = previewWidth / 2 - (previewWidth * scale) / 2 - 6;
-  const translateY = -(previewHeight / 2 - (previewHeight * scale) / 2 - 12);
+  const translateX = previewWidth / 2 - (previewWidth * scale) / 2 - TRANSLATE_X_OFFSET;
+  const translateY = -(previewHeight / 2 - (previewHeight * scale) / 2 - TRANSLATE_Y_OFFSET);
 
   return {
     transform: [

--- a/app/react-native/src/preview/components/OnDeviceUI/animation.ts
+++ b/app/react-native/src/preview/components/OnDeviceUI/animation.ts
@@ -7,7 +7,7 @@ const PREVIEW_WIDE_SCREEN = 0.7;
 
 const panelWidth = (width: number, wide: boolean) => {
   const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
-  return width * (1 - scale - 0.05);
+  return width * (1 - scale - 0.025);
 };
 
 export const getNavigatorPanelPosition = (

--- a/app/react-native/src/preview/components/OnDeviceUI/animation.ts
+++ b/app/react-native/src/preview/components/OnDeviceUI/animation.ts
@@ -3,37 +3,49 @@ import { PreviewDimens } from './absolute-positioned-keyboard-aware-view';
 import { NAVIGATOR, PREVIEW, ADDONS } from './navigation/constants';
 
 const PREVIEW_SCALE = 0.3;
+const PREVIEW_WIDE_SCREEN = 0.7;
 
-const panelWidth = (width: number) => width * (1 - PREVIEW_SCALE - 0.05);
+const panelWidth = (width: number, wide: boolean) => {
+  const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
+  return width * (1 - scale - 0.05);
+};
 
-export const getNavigatorPanelPosition = (animatedValue: Animated.Value, previewWidth: number) => {
+export const getNavigatorPanelPosition = (
+  animatedValue: Animated.Value,
+  previewWidth: number,
+  wide: boolean
+) => {
   return [
     {
       transform: [
         {
           translateX: animatedValue.interpolate({
             inputRange: [NAVIGATOR, PREVIEW],
-            outputRange: [0, -panelWidth(previewWidth) - 1],
+            outputRange: [0, -panelWidth(previewWidth, wide) - 1],
           }),
         },
       ],
-      width: panelWidth(previewWidth),
+      width: panelWidth(previewWidth, wide),
     },
   ];
 };
 
-export const getAddonPanelPosition = (animatedValue: Animated.Value, previewWidth: number) => {
+export const getAddonPanelPosition = (
+  animatedValue: Animated.Value,
+  previewWidth: number,
+  wide: boolean
+) => {
   return [
     {
       transform: [
         {
           translateX: animatedValue.interpolate({
             inputRange: [PREVIEW, ADDONS],
-            outputRange: [previewWidth, previewWidth - panelWidth(previewWidth)],
+            outputRange: [previewWidth, previewWidth - panelWidth(previewWidth, wide)],
           }),
         },
       ],
-      width: panelWidth(previewWidth),
+      width: panelWidth(previewWidth, wide),
     },
   ];
 };
@@ -41,10 +53,12 @@ export const getAddonPanelPosition = (animatedValue: Animated.Value, previewWidt
 export const getPreviewPosition = (
   animatedValue: Animated.Value,
   { width: previewWidth, height: previewHeight }: PreviewDimens,
-  slideBetweenAnimation: boolean
+  slideBetweenAnimation: boolean,
+  wide: boolean
 ) => {
-  const translateX = previewWidth / 2 - (previewWidth * PREVIEW_SCALE) / 2 - 6;
-  const translateY = -(previewHeight / 2 - (previewHeight * PREVIEW_SCALE) / 2 - 12);
+  const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
+  const translateX = previewWidth / 2 - (previewWidth * scale) / 2 - 6;
+  const translateY = -(previewHeight / 2 - (previewHeight * scale) / 2 - 12);
 
   return {
     transform: [
@@ -64,13 +78,18 @@ export const getPreviewPosition = (
   };
 };
 
-export const getPreviewScale = (animatedValue: Animated.Value, slideBetweenAnimation: boolean) => {
+export const getPreviewScale = (
+  animatedValue: Animated.Value,
+  slideBetweenAnimation: boolean,
+  wide: boolean
+) => {
+  const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
   return {
     transform: [
       {
         scale: animatedValue.interpolate({
           inputRange: [NAVIGATOR, PREVIEW, ADDONS],
-          outputRange: [PREVIEW_SCALE, slideBetweenAnimation ? PREVIEW_SCALE : 1, PREVIEW_SCALE],
+          outputRange: [scale, slideBetweenAnimation ? scale : 1, scale],
         }),
       },
     ],

--- a/examples/native/ios/rn_example.xcodeproj/project.pbxproj
+++ b/examples/native/ios/rn_example.xcodeproj/project.pbxproj
@@ -478,6 +478,7 @@
 				PRODUCT_NAME = rn_example;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -499,6 +500,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = rn_example;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;


### PR DESCRIPTION
Issue: #163 

Previously the menu would always scale to 70% of the screen, now if the screen is 1024 or wider it will scale to be 30% and the preview will be 70%.

## What I did

I adjusted the scaling animation so it flips the size of the menu and preview on wide screens for a better experience on the web or ipads etc.

## How to test
run the example app on the web
```sh
cd examples/native

# to run normally
yarn ios

# to run on an ipad
yarn ios --simulator "iPad Pro (12.9-inch) (5th generation)"

# to run on the web
yarn web
```

# screenshots

![image](https://user-images.githubusercontent.com/3481514/142697470-b34354ab-c9fa-4811-a40b-578dd280a412.png)
![image](https://user-images.githubusercontent.com/3481514/142697532-d0c335b1-9890-42fa-b2e2-2fcfa02e2404.png)
![image](https://user-images.githubusercontent.com/3481514/142698524-e8beab04-1786-4fa2-b3b8-503870f67af2.png)
![image](https://user-images.githubusercontent.com/3481514/142698539-67dde82f-1ec7-4308-a27b-a5d8531f89a3.png)

