### PR TITLE
fix: fixed inconsistent control type for 'radio'

### DIFF
--- a/addons/ondevice-controls/src/PropField.tsx
+++ b/addons/ondevice-controls/src/PropField.tsx
@@ -14,7 +14,7 @@ type ControlTypes =
   | 'array'
   | 'date'
   | 'button'
-  | 'radios';
+  | 'radio';
 
 export interface Knob {
   name: string;

--- a/addons/ondevice-controls/src/types/index.ts
+++ b/addons/ondevice-controls/src/types/index.ts
@@ -17,5 +17,5 @@ export default {
   select: SelectType,
   date: DateType,
   array: ArrayType,
-  radios: RadioType,
+  radio: RadioType,
 };

--- a/examples/native/components/ControlExamples/Radio/Radio.stories.tsx
+++ b/examples/native/components/ControlExamples/Radio/Radio.stories.tsx
@@ -13,7 +13,7 @@ const RadioMeta: ComponentMeta<typeof Radio> = {
   argTypes: {
     selection: {
       options: radio_stations,
-      control: { type: 'radios' },
+      control: { type: 'radio' },
     },
   },
 };


### PR DESCRIPTION
Issue: Fixing issue #308 

## What I did
Changed the radio control to work with both Mobile and Web by changing the ControlType string of `radios` to `radio`.

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native?

No, since the original docs of the storybook include the key with 'radio' 

- Does this need an update to the documentation?
No, the changes are accommodated in the storybook original docs. 
![Screenshot 2021-12-26 at 11 14 29 AM](https://user-images.githubusercontent.com/35562287/147400075-68fff8f4-8de1-45e3-a8a4-828141c764ae.png)

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
