### PR TITLE
fix: enforce number data type for number input (#291)

### DIFF
--- a/addons/ondevice-controls/src/ControlsPanel.tsx
+++ b/addons/ondevice-controls/src/ControlsPanel.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/native';
 import { API } from '@storybook/api';
-import React from 'react';
+import React, { useState, useCallback } from 'react';
+import { Args } from '@storybook/addons';
+
 import { useArgs } from './hooks';
 import NoControlsWarning from './NoControlsWarning';
 import PropForm from './PropForm';
@@ -46,8 +48,10 @@ export interface ArgTypes {
 const ControlsPanel = ({ api }: { api: API }) => {
   const store = api.store();
   const storyId = store.getSelection().storyId;
+  const [isPristine, setIsPristine] = useState(true);
   const [argsfromHook, updateArgs, resetArgs] = useArgs(storyId, store);
   const { argTypes, parameters } = store.fromId(storyId);
+
   const argsObject = Object.entries(argsfromHook).reduce((prev, [name, value]) => {
     const isControl = Boolean(argTypes?.[name]?.control);
 
@@ -62,14 +66,27 @@ const ControlsPanel = ({ api }: { api: API }) => {
   const isArgsStory = parameters.__isArgsStory;
   const showWarning = !(hasControls && isArgsStory);
 
+  const updateArgsOnFieldChange = useCallback(
+    (args: Args) => {
+      updateArgs(args);
+      setIsPristine(false);
+    },
+    [updateArgs]
+  );
+
+  const handleReset = () => {
+    resetArgs();
+    setIsPristine(true);
+  };
+
   if (showWarning) {
     return <NoControlsWarning />;
   }
 
   return (
     <>
-      <PropForm args={argsObject} onFieldChange={updateArgs} />
-      <Touchable onPress={() => resetArgs()}>
+      <PropForm args={argsObject} isPristine={isPristine} onFieldChange={updateArgsOnFieldChange} />
+      <Touchable onPress={handleReset}>
         <ResetButton>RESET</ResetButton>
       </Touchable>
     </>

--- a/addons/ondevice-controls/src/PropField.tsx
+++ b/addons/ondevice-controls/src/PropField.tsx
@@ -39,14 +39,19 @@ const Label = styled.Text(({ theme }) => ({
 interface PropFieldProps {
   onChange: (value: any) => void;
   arg: ArgType;
+  isPristine: boolean;
 }
 
-const PropField = ({ onChange, arg }: PropFieldProps) => {
+const PropField = ({ onChange, arg, isPristine }: PropFieldProps) => {
   const InputType: ComponentType<any> = TypeMap[arg.type];
   return (
     <View>
       {!arg.hideLabel ? <Label>{`${arg.label || arg.name}`}</Label> : null}
-      {InputType ? <InputType arg={arg} onChange={onChange} /> : <InvalidType arg={arg} />}
+      {InputType ? (
+        <InputType arg={arg} isPristine={isPristine} onChange={onChange} />
+      ) : (
+        <InvalidType arg={arg} />
+      )}
     </View>
   );
 };

--- a/addons/ondevice-controls/src/PropForm.tsx
+++ b/addons/ondevice-controls/src/PropForm.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { View } from 'react-native';
+import deepEqual from 'deep-equal';
+
 import { ArgTypes } from './ControlsPanel';
 import PropField from './PropField';
 
@@ -25,4 +27,8 @@ const PropForm = ({ args, onFieldChange }: FormProps) => {
   );
 };
 
-export default PropForm;
+const deepStrictEqual = (a: any, b: any): boolean => {
+  return deepEqual(a, b, { strict: true });
+};
+
+export default memo(PropForm, deepStrictEqual);

--- a/addons/ondevice-controls/src/PropForm.tsx
+++ b/addons/ondevice-controls/src/PropForm.tsx
@@ -1,7 +1,5 @@
-import React, { memo } from 'react';
+import React from 'react';
 import { View } from 'react-native';
-import deepEqual from 'deep-equal';
-
 import { ArgTypes } from './ControlsPanel';
 import PropField from './PropField';
 
@@ -27,8 +25,4 @@ const PropForm = ({ args, onFieldChange }: FormProps) => {
   );
 };
 
-const deepStrictEqual = (a: any, b: any): boolean => {
-  return deepEqual(a, b, { strict: true });
-};
-
-export default memo(PropForm, deepStrictEqual);
+export default PropForm;

--- a/addons/ondevice-controls/src/PropForm.tsx
+++ b/addons/ondevice-controls/src/PropForm.tsx
@@ -5,10 +5,11 @@ import PropField from './PropField';
 
 interface FormProps {
   args: ArgTypes;
+  isPristine: boolean;
   onFieldChange: (value: any) => void;
 }
 
-const PropForm = ({ args, onFieldChange }: FormProps) => {
+const PropForm = ({ args, isPristine, onFieldChange }: FormProps) => {
   const makeChangeHandler = (name: string) => {
     return (value) => {
       onFieldChange({ [name]: value });
@@ -19,7 +20,9 @@ const PropForm = ({ args, onFieldChange }: FormProps) => {
     <View>
       {Object.values(args).map((arg) => {
         const changeHandler = makeChangeHandler(arg.name);
-        return <PropField key={arg.name} arg={arg} onChange={changeHandler} />;
+        return (
+          <PropField key={arg.name} arg={arg} isPristine={isPristine} onChange={changeHandler} />
+        );
       })}
     </View>
   );

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Slider from '@react-native-community/slider';
 import styled from '@emotion/native';
@@ -26,18 +26,35 @@ export interface NumberProps {
   onChange: (value: any) => void;
 }
 
+const replaceComma = (value: number | string): string => {
+  return typeof value === 'string' ? value.trim().replace(/,/, '.') : value.toString();
+};
+
 const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
-  const allowComma = typeof arg.value === 'string' ? arg.value.trim().replace(/,/, '.') : arg.value;
-  const showError = Number.isNaN(Number(allowComma));
+  const allowComma = replaceComma(arg.value);
+  const [numStr, setNumStr] = useState(allowComma);
+  const numStrRef = useRef(numStr);
+  const showError = Number.isNaN(Number(numStr));
+
+  const commitChange = () => {
+    onChange(numStr);
+  };
 
   const renderNormal = () => {
     return (
       <Input
         autoCapitalize="none"
         underlineColorAndroid="transparent"
-        value={arg.value.toString()}
+        value={numStr}
         keyboardType="numeric"
-        onChangeText={onChange}
+        onChangeText={(text) => {
+          const commaReplaced = replaceComma(text);
+
+          setNumStr(commaReplaced);
+          numStrRef.current = commaReplaced;
+        }}
+        onSubmitEditing={commitChange}
+        onEndEditing={commitChange}
         style={showError && styles.errorBorder}
       />
     );
@@ -54,6 +71,12 @@ const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
       />
     );
   };
+
+  useEffect(() => {
+    return () => {
+      onChange(numStrRef.current);
+    };
+  }, [onChange]);
 
   return <View style={styles.spacing}>{arg.range ? renderRange() : renderNormal()}</View>;
 };

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Slider from '@react-native-community/slider';
 import styled from '@emotion/native';
@@ -15,7 +15,7 @@ const Input = styled.TextInput(({ theme }) => ({
 export interface NumberProps {
   arg: {
     name: string;
-    value: any;
+    value: number;
     step: number;
     min: number;
     max: number;
@@ -23,21 +23,28 @@ export interface NumberProps {
     defaultValue: number;
   };
 
-  onChange: (value: any) => void;
+  onChange: (value: number) => void;
 }
 
 const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
-  const allowComma = typeof arg.value === 'string' ? arg.value.trim().replace(/,/, '.') : arg.value;
-  const showError = Number.isNaN(Number(allowComma));
+  const showError = Number.isNaN(arg.value);
+  const [numStr, setNumStr] = useState(arg.value.toString());
+
+  const handleNormalChangeText = (text: string) => {
+    const commaReplaced = text.trim().replace(/,/, '.');
+
+    setNumStr(commaReplaced);
+    onChange(Number(commaReplaced));
+  };
 
   const renderNormal = () => {
     return (
       <Input
         autoCapitalize="none"
         underlineColorAndroid="transparent"
-        value={arg.value.toString()}
+        value={numStr}
         keyboardType="numeric"
-        onChangeText={onChange}
+        onChangeText={handleNormalChangeText}
         style={showError && styles.errorBorder}
       />
     );

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import Slider from '@react-native-community/slider';
 import styled from '@emotion/native';
@@ -26,35 +26,18 @@ export interface NumberProps {
   onChange: (value: any) => void;
 }
 
-const replaceComma = (value: number | string): string => {
-  return typeof value === 'string' ? value.trim().replace(/,/, '.') : value.toString();
-};
-
 const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
-  const allowComma = replaceComma(arg.value);
-  const [numStr, setNumStr] = useState(allowComma);
-  const numStrRef = useRef(numStr);
-  const showError = Number.isNaN(Number(numStr));
-
-  const commitChange = () => {
-    onChange(numStr);
-  };
+  const allowComma = typeof arg.value === 'string' ? arg.value.trim().replace(/,/, '.') : arg.value;
+  const showError = Number.isNaN(Number(allowComma));
 
   const renderNormal = () => {
     return (
       <Input
         autoCapitalize="none"
         underlineColorAndroid="transparent"
-        value={numStr}
+        value={arg.value.toString()}
         keyboardType="numeric"
-        onChangeText={(text) => {
-          const commaReplaced = replaceComma(text);
-
-          setNumStr(commaReplaced);
-          numStrRef.current = commaReplaced;
-        }}
-        onSubmitEditing={commitChange}
-        onEndEditing={commitChange}
+        onChangeText={onChange}
         style={showError && styles.errorBorder}
       />
     );
@@ -71,12 +54,6 @@ const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
       />
     );
   };
-
-  useEffect(() => {
-    return () => {
-      onChange(numStrRef.current);
-    };
-  }, [onChange]);
 
   return <View style={styles.spacing}>{arg.range ? renderRange() : renderNormal()}</View>;
 };

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -21,7 +21,6 @@ export interface NumberProps {
     max: number;
     range: boolean;
     defaultValue: number;
-    isPristine: boolean;
   };
   isPristine: boolean;
 

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -34,7 +34,11 @@ const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
     const commaReplaced = text.trim().replace(/,/, '.');
 
     setNumStr(commaReplaced);
-    onChange(Number(commaReplaced));
+    if (commaReplaced === '-') {
+      onChange(-1);
+    } else {
+      onChange(Number(commaReplaced));
+    }
   };
 
   const renderNormal = () => {

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Slider from '@react-native-community/slider';
 import styled from '@emotion/native';
@@ -21,12 +21,14 @@ export interface NumberProps {
     max: number;
     range: boolean;
     defaultValue: number;
+    isPristine: boolean;
   };
+  isPristine: boolean;
 
   onChange: (value: number) => void;
 }
 
-const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
+const NumberType = ({ arg, isPristine, onChange = (value) => value }: NumberProps) => {
   const showError = Number.isNaN(arg.value);
   const [numStr, setNumStr] = useState(arg.value.toString());
 
@@ -40,6 +42,13 @@ const NumberType = ({ arg, onChange = (value) => value }: NumberProps) => {
       onChange(Number(commaReplaced));
     }
   };
+
+  // handle arg.value and numStr out of sync issue on reset
+  useEffect(() => {
+    if (isPristine) {
+      setNumStr(arg.value.toString());
+    }
+  }, [isPristine, arg.value]);
 
   const renderNormal = () => {
     return (

--- a/examples/native/ios/Podfile.lock
+++ b/examples/native/ios/Podfile.lock
@@ -531,11 +531,11 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
   hermes-engine: bf7577d12ac6ccf53ab8b5af3c6ccf0dd8458c5c
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
+  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
   RCTRequired: e5dc0c44cb366fc93383a2bffbc190fe821e7293
   RCTTypeSafety: 6a4d0cfe070e7fd996e797f439b70878764a1ae0
   React: e194f6b2f0a4f8d24065f3ca0a6abe859694df65


### PR DESCRIPTION
Issue: #291 

## What I did

Enforce number data type for number input 

## How to test

Please explain how to test your changes and consider the following questions

- Use a number input control in a story
- Change the value of the input to see it's still a number when rendered in the component

Some cases to consider:
- Input with a comma (e.g. 12,3), expect to see the comma replaced with a dot
- Change the input value and then press on the preview section, expect to see the changes reflected
- Input invalid number format (e.g 12...3), expect to see the input border color changes to signify invalid input
- Clear the input will give a zero value
- Put a - sign only will give NaN, while normal negative numbers will give the value of the number

---

- Does this need a new example in examples/native?

No

- Does this need an update to the documentation?

No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
