### PR TITLE
Add react-native to the resolver array

### DIFF
--- a/examples/native/metro.config.js
+++ b/examples/native/metro.config.js
@@ -17,6 +17,6 @@ module.exports = {
     }),
   },
   resolver: {
-    resolverMainFields: ['sbmodern', 'browser', 'main'],
+    resolverMainFields: ['sbmodern', 'react-native', 'browser', 'main'],
   },
 };

--- a/v6README.md
+++ b/v6README.md
@@ -105,6 +105,7 @@ const defaultConfig = getDefaultConfig(__dirname);
 
 defaultConfig.resolver.resolverMainFields = [
   'sbmodern',
+  'react-native',
   ...defaultConfig.resolver.resolverMainFields,
 ];
 defaultConfig.transformer.getTransformOptions = async () => ({

--- a/v6README.md
+++ b/v6README.md
@@ -68,7 +68,7 @@ expo install @storybook/react-native@next \
 
 Datetime picker, slider and addon-controls are required for controls to work. If you don't want controls you don't need to install these (controls is the knobs replacement).
 
-Continue by updating your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'browser', 'main']}`.
+Continue by updating your metro config to have `resolver:{resolverMainFields: ['sbmodern', 'react-native', 'browser', 'main']}`.
 This enables us to use the modern build of storybook instead of the polyfilled versions.
 
 **Vanilla React Native**
@@ -91,7 +91,7 @@ module.exports = {
     }),
   },
   resolver: {
-    resolverMainFields: ['sbmodern', 'browser', 'main'],
+    resolverMainFields: ['sbmodern', 'react-native', 'browser', 'main'],
   },
 };" > metro.config.js
 ```


### PR DESCRIPTION
Issue: [#255 resolverMainFields breaks uuid library / crypto polyfill](https://github.com/storybookjs/react-native/issues/255)

## What I did
Thanks to @simon-nicholls [comment](https://github.com/storybookjs/react-native/issues/255#issuecomment-963964714)

Add `'react-native'` to the resolverMainField in metro file.
```javascript
    resolverMainFields: ['sbmodern', 'react-native', 'browser', 'main'],

```