### PR TITLE
feat: add number feedback to range slider, minor change onSlidingComplete

### DIFF
--- a/addons/ondevice-controls/src/PropForm.tsx
+++ b/addons/ondevice-controls/src/PropForm.tsx
@@ -1,5 +1,6 @@
+import styled from '@emotion/native';
 import React from 'react';
-import { View } from 'react-native';
+
 import { ArgTypes } from './ControlsPanel';
 import PropField from './PropField';
 
@@ -9,6 +10,8 @@ interface FormProps {
   onFieldChange: (value: any) => void;
 }
 
+const Container = styled.View(() => ({ paddingTop: 8 }));
+
 const PropForm = ({ args, isPristine, onFieldChange }: FormProps) => {
   const makeChangeHandler = (name: string) => {
     return (value) => {
@@ -17,14 +20,14 @@ const PropForm = ({ args, isPristine, onFieldChange }: FormProps) => {
   };
 
   return (
-    <View>
+    <Container>
       {Object.values(args).map((arg) => {
         const changeHandler = makeChangeHandler(arg.name);
         return (
           <PropField key={arg.name} arg={arg} isPristine={isPristine} onChange={changeHandler} />
         );
       })}
-    </View>
+    </Container>
   );
 };
 

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -1,15 +1,34 @@
-import React, { useState, useEffect } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
-import Slider from '@react-native-community/slider';
 import styled from '@emotion/native';
+import Slider from '@react-native-community/slider';
+import React, { useEffect, useState } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
 
 const Input = styled.TextInput(({ theme }) => ({
   borderWidth: 1,
   borderColor: theme.borderColor || '#e6e6e6',
   borderRadius: 2,
-  fontSize: 13,
-  padding: 5,
+  fontSize: 14,
+  paddingVertical: 4,
+  paddingHorizontal: 8,
   color: theme.labelColor || 'black',
+}));
+
+const SliderText = styled.Text(({ theme }) => ({
+  color: theme.labelColor || 'black',
+  fontSize: 14,
+}));
+
+const ValueLabelText = styled.Text(({ theme }) => ({
+  color: theme.secondaryLabelColor || '#999999',
+  fontSize: 14,
+  marginRight: 8,
+}));
+
+const ValueContainer = styled.View({ flexDirection: 'row' });
+
+const NumberSlider = styled(Slider)(() => ({
+  marginTop: Platform.OS === 'android' ? 8 : 4,
+  marginLeft: Platform.OS === 'android' ? -10 : 0,
 }));
 
 export interface NumberProps {
@@ -65,9 +84,11 @@ const NumberType = ({ arg, isPristine, onChange = (value) => value }: NumberProp
   const renderRange = (): React.ReactNode => {
     return (
       <>
-        <Text>{arg.value}</Text>
-        <Slider
-          value={arg.value}
+        <ValueContainer>
+          <ValueLabelText>Value:</ValueLabelText>
+          <SliderText>{arg.value}</SliderText>
+        </ValueContainer>
+        <NumberSlider
           minimumValue={arg.min}
           maximumValue={arg.max}
           step={arg.step}

--- a/addons/ondevice-controls/src/types/Number.tsx
+++ b/addons/ondevice-controls/src/types/Number.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Text } from 'react-native';
 import Slider from '@react-native-community/slider';
 import styled from '@emotion/native';
 
@@ -62,15 +62,18 @@ const NumberType = ({ arg, isPristine, onChange = (value) => value }: NumberProp
     );
   };
 
-  const renderRange = () => {
+  const renderRange = (): React.ReactNode => {
     return (
-      <Slider
-        value={arg.value}
-        minimumValue={arg.min}
-        maximumValue={arg.max}
-        step={arg.step}
-        onSlidingComplete={(val) => onChange(val)}
-      />
+      <>
+        <Text>{arg.value}</Text>
+        <Slider
+          value={arg.value}
+          minimumValue={arg.min}
+          maximumValue={arg.max}
+          step={arg.step}
+          onValueChange={(val) => onChange(val)}
+        />
+      </>
     );
   };
 

--- a/addons/ondevice-controls/src/typings.d.ts
+++ b/addons/ondevice-controls/src/typings.d.ts
@@ -68,6 +68,7 @@ declare module '@emotion/native' {
     previewBorderColor: string;
     buttonTextColor: string;
     buttonActiveTextColor: string;
+    secondaryLabelColor: string;
   };
 
   export interface Styled<Theme extends object = MyTheme, ExtraProps = {}>

--- a/app/react-native/src/preview/components/Shared/theme.ts
+++ b/app/react-native/src/preview/components/Shared/theme.ts
@@ -6,4 +6,5 @@ export const theme = {
   previewBorderColor: '#b3b3b3',
   buttonTextColor: '#999999',
   buttonActiveTextColor: '#444444',
+  secondaryLabelColor: '#999999',
 };


### PR DESCRIPTION
Issue: [discussion-334](https://github.com/storybookjs/react-native/discussions/334) 

## What I did

Added text value for number range based on this [discussion](https://github.com/storybookjs/react-native/discussions/334)  
Non-related to discussion: changed onSlidingComplete to onValueChange for faster feedback. 

## How to test

Can be testing using existing Number control > Range 

https://user-images.githubusercontent.com/36707637/156063674-3c9e62de-d295-467b-8e36-1b14573a6ccb.mov


<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
