### PR TITLE
Log errors when loading stories on device fails

### DIFF
--- a/app/react-native/src/preview/loadCsf.ts
+++ b/app/react-native/src/preview/loadCsf.ts
@@ -68,16 +68,20 @@ const loadStories = (
       });
     });
   } else {
-    const exported = (loadable as LoadableFunction)();
-    if (Array.isArray(exported)) {
-      const csfExports = exported.filter((obj) => obj.default != null);
-      currentExports = new Map(csfExports.map((fileExports) => [fileExports, null]));
-    } else {
-      logger.warn(
-        `Loader function passed to 'configure' should return void or an array of module exports that all contain a 'default' export. Received: ${JSON.stringify(
-          exported
-        )}`
-      );
+    try {
+      const exported = (loadable as LoadableFunction)();
+      if (Array.isArray(exported)) {
+        const csfExports = exported.filter((obj) => obj.default != null);
+        currentExports = new Map(csfExports.map((fileExports) => [fileExports, null]));
+      } else {
+        logger.warn(
+          `Loader function passed to 'configure' should return void or an array of module exports that all contain a 'default' export. Received: ${JSON.stringify(
+            exported
+          )}`
+        );
+      }
+    } catch (error) {
+      logger.warn(`Unexpected error while loading stories: ${error}`);
     }
   }
   const removed = Array.from(global.previousExports.keys()).filter(


### PR DESCRIPTION
Issue: I had a typo in a style definition for one of my components, and although everything worked fine on web, the React Native expo app would stop loading all my stories, without logging any error on the console.

## What I did

I added a `try / catch` block around the `loadable()` function inside `loadCsf.ts`, so that any error that happens inside the `configure()` call (inside `.ondevice/storybook.requires.js`) gets logged.

## How to test

- Add an invalid field (e.g., `aspecRatio`, with a missing t) to a style used by one of your components, and include it in a story
- Run `expo start`
- Launch storybook via expo on your device
- You should now get an error message in your console like:
  ```
  "aspecRatio" is not a valid style property.
  StyleSheet myStyle: {
    "aspecRatio": 1.5,
  }
  Valid style props: [
    "alignContent",
    "alignItems",
    ...```

