### PR TITLE
[bug] Using addon-ondevice-notes crashes app on startup 

### DIFF
--- a/addons/ondevice-notes/src/components/Notes.tsx
+++ b/addons/ondevice-notes/src/components/Notes.tsx
@@ -20,7 +20,7 @@ export const Notes = ({ active, api }: NotesProps) => {
 
   const selection = api.store().getSelection();
 
-  if (!selection) {
+  if (!selection || !Object.keys(selection).length) {
     return null;
   }
 


### PR DESCRIPTION
Issue: #46 

Error reproduction in my application.
![crash_report_1](https://user-images.githubusercontent.com/12099890/172877132-8648ec02-9a2e-4d3a-8b27-60fd13946215.gif)

1- storybook startup
2- choose the addons option
3- choose the notes option.

Reproduction made in version v5.3.25. After the solution presented above has been then tested:

Result:
![storybook-fix](https://user-images.githubusercontent.com/12099890/172877224-97886283-02ea-4eaf-b586-0eae34d22933.gif)

open pull request with solution, please check: https://github.com/storybookjs/react-native/pull/361