### PR TITLE
feat: add story id support to initial selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module.exports = {
 
 ## Decorators and Parameters
 
-For stories you can add decorators and parameters on the default export or on a specifc story 
+For stories you can add decorators and parameters on the default export or on a specifc story
 
 ```jsx
 export default {
@@ -180,8 +180,8 @@ You can pass these parameters to getStorybookUI call in your storybook entry poi
 {
     tabOpen: Number (0)
         -- which tab should be open. -1 Navigator, 0 Preview, 1 Addons
-    initialSelection: Object (null)
-        -- initialize storybook with a specific story.  eg: `{ kind: 'MyButton', name: 'LargeButton' }`
+    initialSelection: string | Object (undefined)
+        -- initialize storybook with a specific story.  eg: `mybutton--largebutton` or `{ kind: 'MyButton', name: 'LargeButton' }`
     shouldDisableKeyboardAvoidingView: Boolean (false)
         -- Disable KeyboardAvoidingView wrapping Storybook's view
     keyboardAvoidingViewVerticalOffset: Number (0)

--- a/app/react-native/src/preview/Preview.tsx
+++ b/app/react-native/src/preview/Preview.tsx
@@ -18,16 +18,19 @@ interface AsyncStorage {
   setItem: (key: string, value: string) => Promise<void>;
 }
 
-interface InitialSelection {
+type StoryKind = string
+type StoryName = string
+
+type InitialSelection = `${StoryKind}--${StoryName}` | {
   /**
    * Kind is the default export name or the storiesOf("name") name
    */
-  kind: string;
+  kind: StoryKind;
 
   /**
    * Name is the named export or the .add("name") name
    */
-  name: string;
+  name: StoryName;
 }
 
 export type Params = {
@@ -120,11 +123,13 @@ export default class Preview {
 
   _getInitialStory = async (initialSelection?: InitialSelection, shouldPersistSelection = true) => {
     let story: string = null;
-    const initialSelectionId = initialSelection
-      ? toId(initialSelection.kind, initialSelection.name)
-      : undefined;
+    const initialSelectionId = initialSelection === undefined
+      ? undefined
+      : typeof initialSelection === 'string'
+        ? initialSelection
+        : toId(initialSelection.kind, initialSelection.name);
 
-    if (initialSelection && initialSelectionId && this._checkStory(initialSelectionId)) {
+    if (initialSelectionId !== undefined && this._checkStory(initialSelectionId)) {
       story = initialSelectionId;
     } else if (shouldPersistSelection) {
       try {


### PR DESCRIPTION
Issue: Add story ID support to the `initialSelection` parameter.

## What I did

Add support for string or object representations of a story ID.

## How to test

Provide a story ID (`path-to-story--story-name`) as a string and your story loads.
