### PR TITLE
better outline

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/VisibilityButton.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/VisibilityButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/native';
+import { View } from 'react-native';
 
 interface Props {
   onPress: () => void;
@@ -13,10 +14,36 @@ const Touchable = styled.TouchableOpacity({
   zIndex: 100,
 });
 
-const HideIcon = styled.Text(({ theme }) => ({
-  fontSize: 14,
-  color: theme.buttonTextColor || '#999999',
+const HIDE_ICON_SIZE = 14;
+const HIDE_ICON_BORDER_WIDTH = 1;
+const Inner = styled.View(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: HIDE_ICON_SIZE,
+  height: HIDE_ICON_SIZE,
+  borderRadius: HIDE_ICON_BORDER_WIDTH,
+  overflow: 'hidden',
+  borderColor: theme.buttonTextColor || '#999999',
+  borderWidth: HIDE_ICON_BORDER_WIDTH * 2,
 }));
+const Outer = styled.View({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: HIDE_ICON_SIZE,
+  height: HIDE_ICON_SIZE,
+  borderRadius: HIDE_ICON_BORDER_WIDTH,
+  overflow: 'hidden',
+  borderColor: 'white',
+  borderWidth: HIDE_ICON_BORDER_WIDTH,
+});
+const HideIcon = () => (
+  <View style={{ width: HIDE_ICON_SIZE, height: HIDE_ICON_SIZE, marginRight: 4 }}>
+    <Inner />
+    <Outer />
+  </View>
+);
 
 const VisibilityButton = ({ onPress }: Props) => (
   <Touchable
@@ -25,7 +52,7 @@ const VisibilityButton = ({ onPress }: Props) => (
     accessibilityLabel="Storybook.OnDeviceUI.toggleUI"
     hitSlop={{ top: 5, left: 5, bottom: 5, right: 5 }}
   >
-    <HideIcon>□</HideIcon>
+    <HideIcon />
   </Touchable>
 );
 export default React.memo(VisibilityButton);


### PR DESCRIPTION
Issue:

I noticed that sometimes it was hard to see the little button
![Screenshot 2022-07-15 at 11 48 42](https://user-images.githubusercontent.com/100233/179203133-493b9a56-6ef5-4c8f-8a03-26cdba93f9b5.png)


## What I did

So I made it with a double outline, so it will work on light and dark back content.
![Screenshot 2022-07-15 at 13 08 52](https://user-images.githubusercontent.com/100233/179203214-ceb5d632-b5e1-4844-9c28-46c72e2b9d6e.png)
![Screenshot 2022-07-15 at 13 08 56](https://user-images.githubusercontent.com/100233/179203229-50d14fd4-8e8f-4fef-b04b-b670ee43cf2b.png)


## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
