### PR TITLE
fix: make react hooks useable in component story

### DIFF
--- a/app/react-native/src/preview/components/StoryView/StoryView.tsx
+++ b/app/react-native/src/preview/components/StoryView/StoryView.tsx
@@ -34,9 +34,11 @@ const StoryView = ({ story }: Props) => {
 
   if (story && story.unboundStoryFn) {
     const { unboundStoryFn } = story;
+    const StoryComponent = (context && context.id === story.id) ? unboundStoryFn : null;
     return (
       <View key={id} testID={id} style={styles.container}>
-        {context && context.id === story.id ? unboundStoryFn(context) : null}
+        {/* We need to get the result by the method of rendering a component, otherwise there will be errors if the react hooks are used */}
+        { StoryComponent && <StoryComponent {...context} /> }
       </View>
     );
   }


### PR DESCRIPTION
Issue: N/A

## What I did

When I added the `useEffect` and other react hooks in component stories, I encountered the `React has detected a change in the order of Hooks` error, after a investigation, found that the story preview content is got by the method of calling the story function, maybe we need to change it to render the story component. :)

<img width="560" alt="image" src="https://user-images.githubusercontent.com/21986828/193496100-64865b34-0a97-4743-bd2f-cfe250a36441.png">


## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native? **NO**
- Does this need an update to the documentation? **NO**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
