### PR TITLE
fix: Results seemingly not matching filter terms

### DIFF
--- a/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
+++ b/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
@@ -61,9 +61,7 @@ const SectionHeader = React.memo(
       <GridIcon />
       <Header selected={selected}>{title}</Header>
     </HeaderContainer>
-  ),
-  (prevProps, nextProps) => prevProps.selected === nextProps.selected
-);
+  ));
 
 interface ListItemProps {
   title: string;


### PR DESCRIPTION
In some cases filtering stories gives what appear to be the wrong results, however they are just being rendered with stale views as a result of an overly aggressive `React.memo` equality function.

## What I did

- Removed the `React.memo` equality function, there's no apparent performance impact (in a Storybook with ~100 stories) but the results are now correct

## How to test

https://user-images.githubusercontent.com/112166/193665022-e074f297-1797-4525-af6e-c946390c715c.mov

See the attached video for a reproduction, but the steps are more or less:

- Select the second story in the list, it needs to be anything other than the first story
- Search for "Date", expecting to find the "Date" stories
- See the results appear to be incorrect
- Select the "incorrect" result, and upon re-rendering the correct result is displayed

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
