### PR TITLE
fix: add defensive check before call m.hot.accept

### DIFF
--- a/app/react-native/src/preview/executeLoadable.ts
+++ b/app/react-native/src/preview/executeLoadable.ts
@@ -68,7 +68,9 @@ global.lastExportsMap = new Map<Path, ModuleExports>();
  * @returns { added: Map<Path, ModuleExports>, removed: Map<Path, ModuleExports> }
  */
 export function executeLoadableForChanges(loadable: Loadable, m?: NodeModule) {
-  m.hot.accept();
+  if (m?.hot?.accept) {
+    m.hot.accept();
+  }
 
   const lastExportsMap = global.lastExportsMap as Map<Path, ModuleExports>;
   const exportsMap = executeLoadable(loadable);


### PR DESCRIPTION
Issue: I found that after upgrade to beta.9 will crashed the app in production mode, after debuging found that it's due to m.hot.accept doesn't existed in non dev mode.

## What I did

Add defensive check for `m.hot.accept` before call

## How to test

I forked [expo-template-storybook](https://github.com/nutstick/expo-template-storybook) and update to use latest version.

To reproduce the issue, can run `yarn start --no-dev`. After add the fixes, it can run without crashed.
