### PR TITLE
docs: correct preview.js example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ import {withBackgrounds} from '@storybook/addon-ondevice-backgrounds';
 export const decorators = [withBackgrounds, (Story)=> <View style={{flex: 1, color: 'blue'}}><Story/></View>];
 export const parameters = {
   backgrounds: {
+    default: 'plain',
     values: [
-      {name: 'plain', value: 'white', default: true},
+      {name: 'plain', value: 'white'},
       {name: 'warm', value: 'hotpink'},
       {name: 'cool', value: 'deepskyblue'},
     ]

--- a/README.md
+++ b/README.md
@@ -116,11 +116,13 @@ For global decorators and parameters you can add them to preview.js inside your 
 import {withBackgrounds} from '@storybook/addon-ondevice-backgrounds';
 export const decorators = [withBackgrounds, (Story)=> <View style={{color: 'blue'}}><Story/></View>];
 export const parameters = {
-  backgrounds: [
-    {name: 'plain', value: 'white', default: true},
-    {name: 'warm', value: 'hotpink'},
-    {name: 'cool', value: 'deepskyblue'},
-  ],
+  backgrounds: {
+    values: [
+      {name: 'plain', value: 'white', default: true},
+      {name: 'warm', value: 'hotpink'},
+      {name: 'cool', value: 'deepskyblue'},
+    ]
+  },
 };
 
 ```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For global decorators and parameters you can add them to preview.js inside your 
 
 ```jsx
 import {withBackgrounds} from '@storybook/addon-ondevice-backgrounds';
-export const decorators = [withBackgrounds, (Story)=> <View style={{color: 'blue'}}><Story/></View>];
+export const decorators = [withBackgrounds, (Story)=> <View style={{flex: 1, color: 'blue'}}><Story/></View>];
 export const parameters = {
   backgrounds: {
     values: [


### PR DESCRIPTION
Issue:

`preview.js` makes error in README.
`addon-ondevice-backgrounds`  needs `values` option.

Error
```
 ERROR  TypeError: undefined is not a function

This error is located at:
    in BackgroundPanel (created by Wrapper)
    in RCTScrollContentView (created by ScrollView)
    in RCTScrollView (created by ScrollView)
    in ScrollView (created by ScrollView)
    in ScrollView (created by Wrapper)
...
```

<img width="436" alt="image" src="https://user-images.githubusercontent.com/216363/208088987-cba25ddd-53ac-4986-b058-66b39cfefb05.png">

It looks `values` is missed in README.


node_modules/@storybook/addon-ondevice-backgrounds/dist/BackgroundPanel.js

53~57
```
    return (react_1.default.createElement(react_native_1.View, null, backgrounds ? (backgrounds.values.map(function (_a) {
        var value = _a.value, name = _a.name;
        return (react_1.default.createElement(react_native_1.View, { key: "".concat(name, " ").concat(value) },
            react_1.default.createElement(Swatch_1.default, { value: value, name: name, setBackground: setBackgroundFromSwatch })));
    })) : (react_1.default.createElement(Instructions, null))));
```

## What I did

Correct README

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native?
No. Example has right option.
- Does this need an update to the documentation?
I did. 

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
