### PR TITLE
feat(rtl): Orient OnDeviceUI correctly for RTL locales

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/animation.ts
+++ b/app/react-native/src/preview/components/OnDeviceUI/animation.ts
@@ -1,8 +1,9 @@
-import { Animated } from 'react-native';
+import { Animated, I18nManager } from 'react-native';
 import { EdgeInsets } from 'react-native-safe-area-context';
 import { PreviewDimens } from './absolute-positioned-keyboard-aware-view';
 import { NAVIGATOR, PREVIEW, ADDONS } from './navigation/constants';
 
+const RTL_SCALE = I18nManager.isRTL ? -1 : 1;
 const PREVIEW_SCALE = 0.3;
 const PREVIEW_WIDE_SCREEN = 0.7;
 const SCALE_OFFSET = 0.025;
@@ -25,7 +26,7 @@ export const getNavigatorPanelPosition = (
         {
           translateX: animatedValue.interpolate({
             inputRange: [NAVIGATOR, PREVIEW],
-            outputRange: [0, -panelWidth(previewWidth, wide) - 1],
+            outputRange: [0, (-panelWidth(previewWidth, wide) - 1) * RTL_SCALE],
           }),
         },
       ],
@@ -45,7 +46,7 @@ export const getAddonPanelPosition = (
         {
           translateX: animatedValue.interpolate({
             inputRange: [PREVIEW, ADDONS],
-            outputRange: [previewWidth, previewWidth - panelWidth(previewWidth, wide)],
+            outputRange: [previewWidth * RTL_SCALE, (previewWidth - panelWidth(previewWidth, wide)) * RTL_SCALE],
           }),
         },
       ],
@@ -72,7 +73,7 @@ export const getPreviewPosition = ({
   insets,
 }: PreviewPositionArgs) => {
   const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
-  const translateX = previewWidth / 2 - (previewWidth * scale) / 2 - TRANSLATE_X_OFFSET;
+  const translateX = (previewWidth / 2 - (previewWidth * scale) / 2 - TRANSLATE_X_OFFSET) * RTL_SCALE;
   const marginTop = noSafeArea ? 0 : insets.top;
   const translateY =
     -(previewHeight / 2 - (previewHeight * scale) / 2 - TRANSLATE_Y_OFFSET) + marginTop;

--- a/examples/native/android/app/src/main/java/com/rn_example/MainActivity.java
+++ b/examples/native/android/app/src/main/java/com/rn_example/MainActivity.java
@@ -1,10 +1,18 @@
 package com.rn_example;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 
 public class MainActivity extends ReactActivity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    I18nUtil sharedI18nUtilInstance = I18nUtil.getInstance();
+    sharedI18nUtilInstance.allowRTL(getApplicationContext(), true);
+  }
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule

--- a/examples/native/ios/rn_example/AppDelegate.mm
+++ b/examples/native/ios/rn_example/AppDelegate.mm
@@ -3,6 +3,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTI18nUtil.h>
 
 #import <React/RCTAppSetupUtils.h>
 
@@ -57,7 +58,19 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+  // Allow RTL layouts, if the device prefers RTL then force the app into RTL layout.
+  [[RCTI18nUtil sharedInstance] allowRTL:YES];
+  if ([self isDevicePreferredLanguageRTL]) {
+    [[RCTI18nUtil sharedInstance] forceRTL:YES];
+  }
   return YES;
+}
+
+- (BOOL)isDevicePreferredLanguageRTL
+{
+  NSLocaleLanguageDirection direction =
+      [NSLocale characterDirectionForLanguage:[[NSLocale preferredLanguages] objectAtIndex:0]];
+  return direction == NSLocaleLanguageDirectionRightToLeft;
 }
 
 /// This method controls whether the `concurrentRoot`feature of React18 is turned on or off.


### PR DESCRIPTION
Issue:

## What I did

Adjust the `OnDeviceUI` transformations to be flipped for RTL locales. This means that "Preview" appears on the right side, while "Addons" appears on the left side, and additionally there is no broken UI overlap in RTL locales.

### Before

https://user-images.githubusercontent.com/112166/212923952-bfcc84f5-b127-4aa0-9954-165174a8e6cc.mp4

### After

https://user-images.githubusercontent.com/112166/212923992-7c527a95-9222-409a-a794-61e895340bc0.mp4

## How to test

Switch the language/region of the device OS to an RTL language (such as Arabic).

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native? **No.**
- Does this need an update to the documentation? **No.**

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
