### PR TITLE
chore: fix missing dep in documentation

### DIFF
--- a/MANUAL_SETUP.md
+++ b/MANUAL_SETUP.md
@@ -30,13 +30,13 @@ You may wish to setup everything yourself, you can use the following guide to do
 **Expo**
 
 ```sh
-expo install @storybook/react-native@next @react-native-async-storage/async-storage
+expo install @storybook/react-native@next @storybook/core-common @react-native-async-storage/async-storage
 ```
 
 **React native CLI**
 
 ```sh
-yarn add -D @storybook/react-native@next @react-native-async-storage/async-storage react-native-safe-area-context
+yarn add -D @storybook/react-native@next @storybook/core-common @react-native-async-storage/async-storage react-native-safe-area-context
 ```
 
 **IOS**


### PR DESCRIPTION
Issue:

```
node:internal/modules/cjs/loader:988
  throw err;
  ^

Error: Cannot find module '@storybook/core-common'
```

## What I did

Missing `@storybook/core-common` dependency in documentation.

## How to test

- Run `sb-rn-get-stories`.
