### PR TITLE
Rerender optimisations

### DIFF
--- a/app/react-native/package.json
+++ b/app/react-native/package.json
@@ -63,6 +63,7 @@
     "commander": "^8.2.0",
     "emotion-theming": "^10.0.19",
     "glob": "^7.1.7",
+    "jotai": "^2.0.2",
     "prettier": "^2.4.1",
     "react-native-swipe-gestures": "^1.0.5",
     "util": "^0.12.4"

--- a/app/react-native/src/hooks.tsx
+++ b/app/react-native/src/hooks.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import type { StoryContext } from '@storybook/csf';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
+
+import type { ReactNativeFramework } from './types/types-6.0';
+
+const storyContextAtom = atom(null as (StoryContext<ReactNativeFramework> | null));
+
+/**
+ * Hook that returns a function to set the current story context.
+ */
+export function useSetStoryContext() {
+  return useSetAtom(storyContextAtom);
+}
+
+/**
+ * Hook to read the current story context.
+ */
+export function useStoryContext() {
+  return useAtomValue(storyContextAtom);
+}
+
+/**
+ * Hook that reads the value of a specific story context parameter.
+ */
+export function useStoryContextParam<T = any>(name: string, defaultValue?: T): T {
+  const paramAtom = useMemo(() => atom(get => get(storyContextAtom)?.parameters?.[name]), [name]);
+  return useAtomValue(paramAtom) ?? defaultValue;
+}
+
+/**
+ * Hook that indicates if `storyId` is the currently selected story.
+ */
+export function useIsStorySelected(storyId: string) {
+  return useAtomValue(useMemo(() => atom(get => get(storyContextAtom)?.id === storyId), [storyId]));
+}
+
+/**
+ * Hook that indicates if `title` is the currently selected story section.
+ */
+export function useIsStorySectionSelected(title: string) {
+  return useAtomValue(useMemo(() => atom(get => get(storyContextAtom)?.title === title), [title]));
+}

--- a/app/react-native/src/preview/View.tsx
+++ b/app/react-native/src/preview/View.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState, useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StoryIndex, SelectionSpecifier } from '@storybook/store';
 import { StoryContext, toId } from '@storybook/csf';
 import { addons } from '@storybook/addons';
 import { ThemeProvider } from 'emotion-theming';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { useSetStoryContext } from '../hooks';
 import OnDeviceUI from './components/OnDeviceUI';
 import { theme } from './components/Shared/theme';
 import type { ReactNativeFramework } from '../types/types-6.0';
@@ -143,7 +144,7 @@ export class View {
 
     const appliedTheme = { ...theme, ...params.theme };
     return () => {
-      const [context, setContext] = useState<StoryContext<ReactNativeFramework>>();
+      const setContext = useSetStoryContext();
       const [, forceUpdate] = useReducer((x) => x + 1, 0);
       useEffect(() => {
         self._setStory = (newStory: StoryContext<ReactNativeFramework>) => {
@@ -166,7 +167,6 @@ export class View {
           <SafeAreaProvider>
             <ThemeProvider theme={appliedTheme}>
               <OnDeviceUI
-                context={context}
                 storyIndex={self._storyIndex}
                 isUIHidden={params.isUIHidden}
                 tabOpen={params.tabOpen}
@@ -177,7 +177,7 @@ export class View {
           </SafeAreaProvider>
         );
       } else {
-        return <StoryView context={context} />;
+        return <StoryView />;
       }
     };
   };

--- a/app/react-native/src/preview/View.tsx
+++ b/app/react-native/src/preview/View.tsx
@@ -160,6 +160,8 @@ export class View {
           self._preview.urlStore.selectionSpecifier = story;
           self._preview.selectSpecifiedStory();
         });
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
 
       if (onDeviceUI) {

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -84,16 +84,16 @@ const OnDeviceUI = ({
 }: OnDeviceUIProps) => {
   const [tabOpen, setTabOpen] = useState(initialTabOpen || PREVIEW);
   const [slideBetweenAnimation, setSlideBetweenAnimation] = useState(false);
-  const [previewDimensions, setPreviewDimensions] = useState<PreviewDimens>({
+  const [previewDimensions, setPreviewDimensions] = useState<PreviewDimens>(() => ({
     width: Dimensions.get('window').width,
     height: Dimensions.get('window').height,
-  });
+  }));
   const animatedValue = useRef(new Animated.Value(tabOpen));
   const wide = useWindowDimensions().width >= BREAKPOINT;
   const insets = useSafeAreaInsets();
   const [isUIVisible, setIsUIVisible] = useState(isUIHidden !== undefined ? !isUIHidden : true);
 
-  const handleToggleTab = (newTabOpen: number) => {
+  const handleToggleTab = React.useCallback((newTabOpen: number) => {
     if (newTabOpen === tabOpen) {
       return;
     }
@@ -110,7 +110,7 @@ const OnDeviceUI = ({
     if (newTabOpen === PREVIEW) {
       Keyboard.dismiss();
     }
-  };
+  }, [tabOpen]);
 
   const noSafeArea = context?.parameters?.noSafeArea ?? false;
   const previewWrapperStyles = [

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -14,6 +14,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
+import { useStoryContextParam } from '../../../hooks';
 import StoryListView from '../StoryListView';
 import StoryView from '../StoryView';
 import AbsolutePositionedKeyboardAwareView, {
@@ -32,8 +33,6 @@ import { PREVIEW, ADDONS } from './navigation/constants';
 import Panel from './Panel';
 import { useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { StoryContext } from '@storybook/csf';
-import { ReactNativeFramework } from 'src/types/types-6.0';
 
 const ANIMATION_DURATION = 300;
 const IS_IOS = Platform.OS === 'ios';
@@ -43,7 +42,6 @@ export const IS_EXPO = getExpoRoot() !== undefined;
 const IS_ANDROID = Platform.OS === 'android';
 const BREAKPOINT = 1024;
 interface OnDeviceUIProps {
-  context: StoryContext<ReactNativeFramework>;
   storyIndex: StoryIndex;
   url?: string;
   tabOpen?: number;
@@ -75,7 +73,6 @@ const styles = StyleSheet.create({
 });
 
 const OnDeviceUI = ({
-  context,
   storyIndex,
   isUIHidden,
   shouldDisableKeyboardAvoidingView,
@@ -112,7 +109,7 @@ const OnDeviceUI = ({
     }
   }, [tabOpen]);
 
-  const noSafeArea = context?.parameters?.noSafeArea ?? false;
+  const noSafeArea = useStoryContextParam<boolean>('noSafeArea', false);
   const previewWrapperStyles = [
     flex,
     getPreviewPosition({
@@ -146,7 +143,7 @@ const OnDeviceUI = ({
               <Animated.View style={previewStyles}>
                 <Preview disabled={tabOpen === PREVIEW}>
                   <WrapperView style={[flex, wrapperMargin]}>
-                    <StoryView context={context} />
+                    <StoryView />
                   </WrapperView>
                 </Preview>
                 {tabOpen !== PREVIEW ? (
@@ -164,7 +161,7 @@ const OnDeviceUI = ({
                 wide
               )}
             >
-              <StoryListView storyIndex={storyIndex} selectedStoryContext={context} />
+              <StoryListView storyIndex={storyIndex} />
             </Panel>
 
             <Panel

--- a/app/react-native/src/preview/components/OnDeviceUI/absolute-positioned-keyboard-aware-view.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/absolute-positioned-keyboard-aware-view.tsx
@@ -20,10 +20,13 @@ const AbsolutePositionedKeyboardAwareView = ({
   children,
 }: Props) => {
   const onLayoutHandler = ({ nativeEvent }: LayoutChangeEvent) => {
-    onLayout({
-      height: nativeEvent.layout.height,
-      width: nativeEvent.layout.width,
-    });
+    const {height: layoutHeight, width: layoutWidth} = nativeEvent.layout;
+    if (layoutHeight !== height || layoutWidth !== width) {
+      onLayout({
+        height: layoutHeight,
+        width: layoutWidth,
+      });
+    }
   };
 
   return (

--- a/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
+++ b/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
@@ -131,6 +131,10 @@ const styles = StyleSheet.create({
 const tabBarHeight = 40;
 
 const StoryListView = ({ selectedStoryContext, storyIndex }: Props) => {
+function keyExtractor(item: any, index) {
+  return item.id + index;
+}
+
   const insets = useSafeAreaInsets();
   const originalData = useMemo(() => getStories(storyIndex), [storyIndex]);
   const [data, setData] = useState<DataItem[]>(originalData);
@@ -167,7 +171,27 @@ const StoryListView = ({ selectedStoryContext, storyIndex }: Props) => {
     channel.emit(Events.SET_CURRENT_STORY, { storyId });
   };
 
-  const safeStyle = { flex: 1, marginTop: insets.top, paddingBottom: insets.bottom + tabBarHeight };
+  const safeStyle = React.useMemo(() => {
+    return { flex: 1, marginTop: insets.top, paddingBottom: insets.bottom + tabBarHeight };
+  }, [insets]);
+
+  const renderItem: SectionListRenderItem<StoryIndexEntry, DataItem> = React.useCallback(({item}) => {
+    return (
+      <ListItem
+        title={item.name}
+        kind={item.title}
+        selected={selectedStoryContext && item.id === selectedStoryContext.id}
+        onPress={() => changeStory(item.id)}
+      />
+    );
+  }, []);
+
+  const renderSectionHeader = React.useCallback(({ section: { title } }) => (
+    <SectionHeader
+      title={title}
+      selected={selectedStoryContext && title === selectedStoryContext.title}
+    />
+  ), []);
 
   return (
     <StoryListContainer>
@@ -184,21 +208,9 @@ const StoryListView = ({ selectedStoryContext, storyIndex }: Props) => {
           // contentInset={{ bottom: insets.bottom, top: 0 }}
           style={styles.sectionList}
           testID="Storybook.ListView"
-          renderItem={({ item }) => (
-            <ListItem
-              title={item.name}
-              kind={item.title}
-              selected={selectedStoryContext && item.id === selectedStoryContext.id}
-              onPress={() => changeStory(item.id)}
-            />
-          )}
-          renderSectionHeader={({ section: { title } }) => (
-            <SectionHeader
-              title={title}
-              selected={selectedStoryContext && title === selectedStoryContext.title}
-            />
-          )}
-          keyExtractor={(item, index) => item.id + index}
+          renderItem={renderItem}
+          renderSectionHeader={renderSectionHeader}
+          keyExtractor={keyExtractor}
           sections={data}
           stickySectionHeadersEnabled={false}
         />
@@ -207,4 +219,4 @@ const StoryListView = ({ selectedStoryContext, storyIndex }: Props) => {
   );
 };
 
-export default StoryListView;
+export default React.memo(StoryListView);

--- a/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
+++ b/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
@@ -2,13 +2,17 @@ import styled from '@emotion/native';
 import { addons, StoryKind } from '@storybook/addons';
 import { StoryIndex, StoryIndexEntry } from '@storybook/client-api';
 import Events from '@storybook/core-events';
-import { StoryContext } from '@storybook/csf';
 import React, { useMemo, useState } from 'react';
-import { SectionList, StyleSheet, View } from 'react-native';
+import {
+  SectionList,
+  SectionListRenderItem,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { GridIcon, StoryIcon } from '../Shared/icons';
 import { Header, Name } from '../Shared/text';
-import { ReactNativeFramework } from 'src/types/types-6.0';
+import { useIsStorySelected, useIsStorySectionSelected } from '../../../hooks';
 
 const SearchBar = styled.TextInput(
   {
@@ -54,20 +58,22 @@ const StoryListContainer = styled.View(({ theme }) => ({
 
 interface SectionProps {
   title: string;
-  selected: boolean;
 }
 
-const SectionHeader = React.memo(({ title, selected }: SectionProps) => (
-  <HeaderContainer key={title}>
-    <GridIcon />
-    <Header selected={selected}>{title}</Header>
-  </HeaderContainer>
-));
+const SectionHeader = React.memo(({ title }: SectionProps) => {
+  const selected = useIsStorySectionSelected(title);
+  return (
+    <HeaderContainer key={title}>
+      <GridIcon />
+      <Header selected={selected}>{title}</Header>
+    </HeaderContainer>
+  );
+});
 
 interface ListItemProps {
+  storyId: string;
   title: string;
   kind: string;
-  selected: boolean;
   onPress: () => void;
 }
 
@@ -82,25 +88,27 @@ const ItemTouchable = styled.TouchableOpacity<{ selected: boolean }>(
 );
 
 const ListItem = React.memo(
-  ({ kind, title, selected, onPress }: ListItemProps) => (
-    <ItemTouchable
-      key={title}
-      onPress={onPress}
-      activeOpacity={0.8}
-      testID={`Storybook.ListItem.${kind}.${title}`}
-      accessibilityLabel={`Storybook.ListItem.${title}`}
-      selected={selected}
-    >
-      <StoryIcon selected={selected} />
-      <Name selected={selected}>{title}</Name>
-    </ItemTouchable>
-  ),
-  (prevProps, nextProps) => prevProps.selected === nextProps.selected
+  ({ storyId, kind, title, onPress }: ListItemProps) => {
+    const selected = useIsStorySelected(storyId);
+    return (
+      <ItemTouchable
+        key={title}
+        onPress={onPress}
+        activeOpacity={0.8}
+        testID={`Storybook.ListItem.${kind}.${title}`}
+        accessibilityLabel={`Storybook.ListItem.${title}`}
+        selected={selected}
+      >
+        <StoryIcon selected={selected} />
+        <Name selected={selected}>{title}</Name>
+      </ItemTouchable>
+    );
+  },
+  (prevProps, nextProps) => prevProps.storyId === nextProps.storyId
 );
 
 interface Props {
   storyIndex: StoryIndex;
-  selectedStoryContext: StoryContext<ReactNativeFramework>;
 }
 
 interface DataItem {
@@ -130,11 +138,11 @@ const styles = StyleSheet.create({
 
 const tabBarHeight = 40;
 
-const StoryListView = ({ selectedStoryContext, storyIndex }: Props) => {
 function keyExtractor(item: any, index) {
   return item.id + index;
 }
 
+const StoryListView = ({ storyIndex }: Props) => {
   const insets = useSafeAreaInsets();
   const originalData = useMemo(() => getStories(storyIndex), [storyIndex]);
   const [data, setData] = useState<DataItem[]>(originalData);
@@ -178,19 +186,16 @@ function keyExtractor(item: any, index) {
   const renderItem: SectionListRenderItem<StoryIndexEntry, DataItem> = React.useCallback(({item}) => {
     return (
       <ListItem
+        storyId={item.id}
         title={item.name}
         kind={item.title}
-        selected={selectedStoryContext && item.id === selectedStoryContext.id}
         onPress={() => changeStory(item.id)}
       />
     );
   }, []);
 
   const renderSectionHeader = React.useCallback(({ section: { title } }) => (
-    <SectionHeader
-      title={title}
-      selected={selectedStoryContext && title === selectedStoryContext.title}
-    />
+    <SectionHeader title={title} />
   ), []);
 
   return (

--- a/app/react-native/src/preview/components/StoryView/StoryView.tsx
+++ b/app/react-native/src/preview/components/StoryView/StoryView.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 
 import { Text, View, StyleSheet } from 'react-native';
-import type { StoryContext } from '@storybook/csf';
-import { ReactNativeFramework } from 'src/types/types-6.0';
-
-interface Props {
-  context?: StoryContext<ReactNativeFramework>;
-}
+import { useStoryContext } from '../../../hooks';
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
@@ -19,7 +14,8 @@ const styles = StyleSheet.create({
   },
 });
 
-const StoryView = ({ context }: Props) => {
+const StoryView = () => {
+  const context = useStoryContext();
   const id = context?.id;
 
   if (context && context.unboundStoryFn) {

--- a/app/react-native/src/preview/components/StoryView/StoryView.tsx
+++ b/app/react-native/src/preview/components/StoryView/StoryView.tsx
@@ -39,4 +39,4 @@ const StoryView = ({ context }: Props) => {
   );
 };
 
-export default StoryView;
+export default React.memo(StoryView);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13025,6 +13025,11 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+jotai@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.2.tgz#52728e91de61742263e40fda79a367ab4649506c"
+  integrity sha512-0yOked08Swa84LUbBjtj7ZLZrE05n3u50rHeZ+bsT86thUjcy0kFgQz9GmEWhYbQDFoT1G8Ww6edSj/MBJHO4A==
+
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"


### PR DESCRIPTION
Issue:

A lot of interactions in Storybook are much less responsive than they should be, the profiler indicates that large tree hierarchies are rerendered that result in no UI changes.

## What I did

- Profile various interactions
  - Switching stories
  - Adjust addon properties (knobs, controls, background, etc.)
  - Switching navigation / preview / addons tabs
- Apply memoization to props that were frequent causes of rerenders, when their data hadn't changed meaningfully
- Apply memoization to components that can often avoid being rerendered (such as when switching tabs) 
- Introduced [jotai](https://jotai.org/) to lift the story context state out of `OnDeviceUI`'s parent, and read the state closer to where it needs to be instead of using prop-drilling

Below are screenshots from the profiler of the longest commit when switching stories. The gist of it is that views that were previously re-rendering just because the parent re-rendered are now not doing that, and only the relevant story list items (the one that was selected, and the one that will become selected) are updating.

The net result is a significant improvement to responsiveness, even in a dev build.

The exact numbers are somewhat unreliable because it's not a release build, but that factor between them is probably a reasonable indication.

| Before | After |
|------|---------------|
|  ![image](https://user-images.githubusercontent.com/112166/219486273-b8ad77d1-5462-4a27-a3a9-38e0386e038b.png)  | ![image](https://user-images.githubusercontent.com/112166/219486245-1dfaae19-62b1-440e-bc56-df15825e383e.png) |

## How to test

Unfortunately there are no benchmark/performance tests, so it has to mostly be manually by performing typical Storybook operations:

- Switching stories
- Switching tabs
- Filtering stories
- Manipulating addon controls

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
