### PR TITLE
Fix safe area stories cut off

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -103,6 +103,7 @@ const OnDeviceUI = ({
   const animatedValue = useRef(new Animated.Value(tabOpen));
   const wide = useWindowDimensions().width >= BREAKPOINT;
   const insets = useSafeAreaInsets();
+  const theme: any = useTheme();
   const [isUIVisible, setIsUIVisible] = useState(isUIHidden !== undefined ? !isUIHidden : true);
 
   const handleToggleTab = React.useCallback(
@@ -162,8 +163,8 @@ const OnDeviceUI = ({
   //
   //   4. Storybook UI is not visible, and `noSafeArea` is true: No margin.
   const safeAreaMargins = {
-    marginBottom: isUIVisible ? insets.bottom + navBarHeight : noSafeArea ? 0 : insets.bottom,
-    marginTop: !noSafeArea ? insets.top : 0,
+    paddingBottom: isUIVisible ? insets.bottom + navBarHeight : noSafeArea ? 0 : insets.bottom,
+    paddingTop: !noSafeArea ? insets.top : 0,
   };
   return (
     <>
@@ -190,11 +191,11 @@ const OnDeviceUI = ({
               ) : null}
             </Animated.View>
             <Panel
-              style={getNavigatorPanelPosition(
-                animatedValue.current,
-                previewDimensions.width,
-                wide
-              )}
+              style={[
+                getNavigatorPanelPosition(animatedValue.current, previewDimensions.width, wide),
+                safeAreaMargins,
+                { backgroundColor: theme.storyListBackgroundColor },
+              ]}
             >
               <StoryListView storyIndex={storyIndex} />
             </Panel>

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -119,8 +119,6 @@ const OnDeviceUI = ({
       previewDimensions,
       slideBetweenAnimation,
       wide,
-      noSafeArea,
-      insets,
     }),
   ];
 

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -92,24 +92,27 @@ const OnDeviceUI = ({
   const insets = useSafeAreaInsets();
   const [isUIVisible, setIsUIVisible] = useState(isUIHidden !== undefined ? !isUIHidden : true);
 
-  const handleToggleTab = React.useCallback((newTabOpen: number) => {
-    if (newTabOpen === tabOpen) {
-      return;
-    }
-    Animated.timing(animatedValue.current, {
-      toValue: newTabOpen,
-      duration: ANIMATION_DURATION,
-      useNativeDriver: true,
-    }).start();
-    setTabOpen(newTabOpen);
-    const isSwipingBetweenNavigatorAndAddons = tabOpen + newTabOpen === PREVIEW;
-    setSlideBetweenAnimation(isSwipingBetweenNavigatorAndAddons);
+  const handleToggleTab = React.useCallback(
+    (newTabOpen: number) => {
+      if (newTabOpen === tabOpen) {
+        return;
+      }
+      Animated.timing(animatedValue.current, {
+        toValue: newTabOpen,
+        duration: ANIMATION_DURATION,
+        useNativeDriver: true,
+      }).start();
+      setTabOpen(newTabOpen);
+      const isSwipingBetweenNavigatorAndAddons = tabOpen + newTabOpen === PREVIEW;
+      setSlideBetweenAnimation(isSwipingBetweenNavigatorAndAddons);
 
-    // close the keyboard opened from a TextInput from story list or knobs
-    if (newTabOpen === PREVIEW) {
-      Keyboard.dismiss();
-    }
-  }, [tabOpen]);
+      // close the keyboard opened from a TextInput from story list or knobs
+      if (newTabOpen === PREVIEW) {
+        Keyboard.dismiss();
+      }
+    },
+    [tabOpen]
+  );
 
   const noSafeArea = useStoryContextParam<boolean>('noSafeArea', false);
   const previewWrapperStyles = [

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -1,18 +1,19 @@
-import styled from '@emotion/native';
 import { StoryIndex } from '@storybook/client-api';
+import { useTheme } from 'emotion-theming';
 import React, { useState, useRef } from 'react';
 import {
   Animated,
   Dimensions,
-  FlexStyle,
+  Easing,
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  SafeAreaView,
   TouchableOpacity,
   StatusBar,
   StyleSheet,
   View,
+  ViewStyle,
+  StyleProp,
 } from 'react-native';
 import { useStoryContextParam } from '../../../hooks';
 import StoryListView from '../StoryListView';
@@ -25,8 +26,8 @@ import Addons from './addons/Addons';
 import {
   getAddonPanelPosition,
   getNavigatorPanelPosition,
-  getPreviewPosition,
-  getPreviewScale,
+  getPreviewShadowStyle,
+  getPreviewStyle,
 } from './animation';
 import Navigation from './navigation';
 import { PREVIEW, ADDONS } from './navigation/constants';
@@ -34,13 +35,14 @@ import Panel from './Panel';
 import { useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const ANIMATION_DURATION = 300;
+const ANIMATION_DURATION = 400;
 const IS_IOS = Platform.OS === 'ios';
 // @ts-ignore: Property 'Expo' does not exist on type 'Global'
 const getExpoRoot = () => global.Expo || global.__expo || global.__exponent;
 export const IS_EXPO = getExpoRoot() !== undefined;
 const IS_ANDROID = Platform.OS === 'android';
 const BREAKPOINT = 1024;
+
 interface OnDeviceUIProps {
   storyIndex: StoryIndex;
   url?: string;
@@ -52,23 +54,27 @@ interface OnDeviceUIProps {
 
 const flex = { flex: 1 };
 
-const Preview = styled.View<{ disabled: boolean }>(flex, ({ disabled, theme }) => ({
-  borderLeftWidth: disabled ? 0 : 1,
-  borderTopWidth: disabled ? 0 : 1,
-  borderRightWidth: disabled ? 0 : 1,
-  borderBottomWidth: disabled ? 0 : 1,
-  borderColor: disabled ? 'transparent' : theme.previewBorderColor,
-  borderRadius: disabled ? 0 : 12,
-  overflow: 'hidden',
-}));
+interface PreviewProps {
+  animatedValue: Animated.Value;
+  style: StyleProp<ViewStyle>;
+  children?: React.ReactNode;
+}
 
-const absolutePosition: FlexStyle = {
-  position: 'absolute',
-  top: 0,
-  bottom: 0,
-  left: 0,
-  right: 0,
-};
+/**
+ * Story preview container.
+ */
+function Preview({ animatedValue, style, children }: PreviewProps) {
+  const theme: any = useTheme();
+  const containerStyle = {
+    backgroundColor: theme.backgroundColor,
+    ...getPreviewShadowStyle(animatedValue),
+  };
+  return (
+    <Animated.View style={[flex, containerStyle]}>
+      <View style={[flex, style]}>{children}</View>
+    </Animated.View>
+  );
+}
 
 const styles = StyleSheet.create({
   expoAndroidContainer: { paddingTop: StatusBar.currentHeight },
@@ -82,7 +88,7 @@ const OnDeviceUI = ({
   tabOpen: initialTabOpen,
 }: OnDeviceUIProps) => {
   const [tabOpen, setTabOpen] = useState(initialTabOpen || PREVIEW);
-  const [slideBetweenAnimation, setSlideBetweenAnimation] = useState(false);
+  const lastTabOpen = React.useRef(tabOpen);
   const [previewDimensions, setPreviewDimensions] = useState<PreviewDimens>(() => ({
     width: Dimensions.get('window').width,
     height: Dimensions.get('window').height,
@@ -97,14 +103,14 @@ const OnDeviceUI = ({
       if (newTabOpen === tabOpen) {
         return;
       }
+      lastTabOpen.current = tabOpen;
       Animated.timing(animatedValue.current, {
         toValue: newTabOpen,
         duration: ANIMATION_DURATION,
+        easing: Easing.inOut(Easing.cubic),
         useNativeDriver: true,
       }).start();
       setTabOpen(newTabOpen);
-      const isSwipingBetweenNavigatorAndAddons = tabOpen + newTabOpen === PREVIEW;
-      setSlideBetweenAnimation(isSwipingBetweenNavigatorAndAddons);
 
       // close the keyboard opened from a TextInput from story list or knobs
       if (newTabOpen === PREVIEW) {
@@ -117,18 +123,41 @@ const OnDeviceUI = ({
   const noSafeArea = useStoryContextParam<boolean>('noSafeArea', false);
   const previewWrapperStyles = [
     flex,
-    getPreviewPosition({
+    getPreviewStyle({
       animatedValue: animatedValue.current,
       previewDimensions,
-      slideBetweenAnimation,
       wide,
+      insets,
+      tabOpen,
+      lastTabOpen: lastTabOpen.current,
     }),
   ];
 
-  const previewStyles = [flex, getPreviewScale(animatedValue.current, slideBetweenAnimation, wide)];
+  // The initial value is just a guess until the layout calculation has been done.
+  const [navBarHeight, setNavBarHeight] = React.useState(insets.bottom + 40);
+  const measureNavigation = React.useCallback(
+    ({ nativeEvent }) => {
+      const inset = insets.bottom;
+      setNavBarHeight(isUIVisible ? nativeEvent.layout.height - inset : 0);
+    },
+    [isUIVisible, insets]
+  );
 
-  const WrapperView = noSafeArea ? View : SafeAreaView;
-  const wrapperMargin = { marginBottom: isUIVisible ? insets.bottom + 40 : 0 };
+  // There are 4 cases for the additional UI margin:
+  //   1. Storybook UI is visible, and `noSafeArea` is false: Include top and
+  //      bottom safe area insets, and also include the navigation bar height.
+  //
+  //   2. Storybook UI is not visible, and `noSafeArea` is false: Include top
+  //      and bottom safe area insets.
+  //
+  //   3. Storybook UI is visible, and `noSafeArea` is true: Include only the
+  //      bottom safe area inset and the navigation bar height.
+  //
+  //   4. Storybook UI is not visible, and `noSafeArea` is true: No margin.
+  const safeAreaMargins = {
+    marginBottom: isUIVisible ? insets.bottom + navBarHeight : noSafeArea ? 0 : insets.bottom,
+    marginTop: !noSafeArea ? insets.top : 0,
+  };
   return (
     <>
       <View style={[flex, IS_ANDROID && IS_EXPO && styles.expoAndroidContainer]}>
@@ -143,19 +172,15 @@ const OnDeviceUI = ({
             previewDimensions={previewDimensions}
           >
             <Animated.View style={previewWrapperStyles}>
-              <Animated.View style={previewStyles}>
-                <Preview disabled={tabOpen === PREVIEW}>
-                  <WrapperView style={[flex, wrapperMargin]}>
-                    <StoryView />
-                  </WrapperView>
-                </Preview>
-                {tabOpen !== PREVIEW ? (
-                  <TouchableOpacity
-                    style={absolutePosition}
-                    onPress={() => handleToggleTab(PREVIEW)}
-                  />
-                ) : null}
-              </Animated.View>
+              <Preview style={safeAreaMargins} animatedValue={animatedValue.current}>
+                <StoryView />
+              </Preview>
+              {tabOpen !== PREVIEW ? (
+                <TouchableOpacity
+                  style={StyleSheet.absoluteFillObject}
+                  onPress={() => handleToggleTab(PREVIEW)}
+                />
+              ) : null}
             </Animated.View>
             <Panel
               style={getNavigatorPanelPosition(
@@ -170,7 +195,7 @@ const OnDeviceUI = ({
             <Panel
               style={[
                 getAddonPanelPosition(animatedValue.current, previewDimensions.width, wide),
-                wrapperMargin,
+                safeAreaMargins,
               ]}
             >
               <Addons active={tabOpen === ADDONS} />
@@ -178,6 +203,7 @@ const OnDeviceUI = ({
           </AbsolutePositionedKeyboardAwareView>
         </KeyboardAvoidingView>
         <Navigation
+          onLayout={measureNavigation}
           tabOpen={tabOpen}
           onChangeTab={handleToggleTab}
           isUIVisible={isUIVisible}

--- a/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/OnDeviceUI.tsx
@@ -1,4 +1,5 @@
 import { StoryIndex } from '@storybook/client-api';
+import styled from '@emotion/native';
 import { useTheme } from 'emotion-theming';
 import React, { useState, useRef } from 'react';
 import {
@@ -80,6 +81,12 @@ const styles = StyleSheet.create({
   expoAndroidContainer: { paddingTop: StatusBar.currentHeight },
 });
 
+const Container = styled.View(({ theme }) => ({
+  flex: 1,
+  backgroundColor: theme.backgroundColor,
+  ...(IS_ANDROID && IS_EXPO ? styles.expoAndroidContainer : undefined),
+}));
+
 const OnDeviceUI = ({
   storyIndex,
   isUIHidden,
@@ -160,7 +167,7 @@ const OnDeviceUI = ({
   };
   return (
     <>
-      <View style={[flex, IS_ANDROID && IS_EXPO && styles.expoAndroidContainer]}>
+      <Container>
         <KeyboardAvoidingView
           enabled={!shouldDisableKeyboardAvoidingView || tabOpen !== PREVIEW}
           behavior={IS_IOS ? 'padding' : null}
@@ -209,7 +216,7 @@ const OnDeviceUI = ({
           isUIVisible={isUIVisible}
           setIsUIVisible={setIsUIVisible}
         />
-      </View>
+      </Container>
     </>
   );
 };

--- a/app/react-native/src/preview/components/OnDeviceUI/animation.ts
+++ b/app/react-native/src/preview/components/OnDeviceUI/animation.ts
@@ -1,5 +1,4 @@
 import { Animated, I18nManager } from 'react-native';
-import { EdgeInsets } from 'react-native-safe-area-context';
 import { PreviewDimens } from './absolute-positioned-keyboard-aware-view';
 import { NAVIGATOR, PREVIEW, ADDONS } from './navigation/constants';
 
@@ -46,7 +45,10 @@ export const getAddonPanelPosition = (
         {
           translateX: animatedValue.interpolate({
             inputRange: [PREVIEW, ADDONS],
-            outputRange: [previewWidth * RTL_SCALE, (previewWidth - panelWidth(previewWidth, wide)) * RTL_SCALE],
+            outputRange: [
+              previewWidth * RTL_SCALE,
+              (previewWidth - panelWidth(previewWidth, wide)) * RTL_SCALE,
+            ],
           }),
         },
       ],
@@ -60,8 +62,6 @@ type PreviewPositionArgs = {
   previewDimensions: PreviewDimens;
   slideBetweenAnimation: boolean;
   wide: boolean;
-  noSafeArea: boolean;
-  insets: EdgeInsets;
 };
 
 export const getPreviewPosition = ({
@@ -69,14 +69,11 @@ export const getPreviewPosition = ({
   previewDimensions: { width: previewWidth, height: previewHeight },
   slideBetweenAnimation,
   wide,
-  noSafeArea,
-  insets,
 }: PreviewPositionArgs) => {
   const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
-  const translateX = (previewWidth / 2 - (previewWidth * scale) / 2 - TRANSLATE_X_OFFSET) * RTL_SCALE;
-  const marginTop = noSafeArea ? 0 : insets.top;
-  const translateY =
-    -(previewHeight / 2 - (previewHeight * scale) / 2 - TRANSLATE_Y_OFFSET) + marginTop;
+  const translateX =
+    (previewWidth / 2 - (previewWidth * scale) / 2 - TRANSLATE_X_OFFSET) * RTL_SCALE;
+  const translateY = -(previewHeight / 2 - (previewHeight * scale) / 2 - TRANSLATE_Y_OFFSET);
 
   return {
     transform: [
@@ -89,7 +86,7 @@ export const getPreviewPosition = ({
       {
         translateY: animatedValue.interpolate({
           inputRange: [NAVIGATOR, PREVIEW, ADDONS],
-          outputRange: [translateY, slideBetweenAnimation ? translateY : marginTop, translateY],
+          outputRange: [translateY, slideBetweenAnimation ? translateY : 0, translateY],
         }),
       },
     ],

--- a/app/react-native/src/preview/components/OnDeviceUI/animation.ts
+++ b/app/react-native/src/preview/components/OnDeviceUI/animation.ts
@@ -1,16 +1,20 @@
-import { Animated, I18nManager } from 'react-native';
+import { Animated, I18nManager, Insets } from 'react-native';
 import { PreviewDimens } from './absolute-positioned-keyboard-aware-view';
 import { NAVIGATOR, PREVIEW, ADDONS } from './navigation/constants';
 
+// Factor that will flip the animation orientation in RTL locales.
 const RTL_SCALE = I18nManager.isRTL ? -1 : 1;
+// Percentage to scale the preview area by when opening a panel.
 const PREVIEW_SCALE = 0.3;
-const PREVIEW_WIDE_SCREEN = 0.7;
+// Percentage to scale the preview area by when opening a panel, on wide screens.
+const PREVIEW_SCALE_WIDE = 0.7;
+// Percentage to shrink the visible preview by, without affecting the panel size.
+const PREVIEW_SCALE_SHRINK = 0.9;
 const SCALE_OFFSET = 0.025;
-const TRANSLATE_X_OFFSET = 6;
 const TRANSLATE_Y_OFFSET = 12;
 
 const panelWidth = (width: number, wide: boolean) => {
-  const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
+  const scale = wide ? PREVIEW_SCALE_WIDE : PREVIEW_SCALE;
   return width * (1 - scale - SCALE_OFFSET);
 };
 
@@ -60,20 +64,39 @@ export const getAddonPanelPosition = (
 type PreviewPositionArgs = {
   animatedValue: Animated.Value;
   previewDimensions: PreviewDimens;
-  slideBetweenAnimation: boolean;
   wide: boolean;
+  insets: Insets;
+  tabOpen: number;
+  lastTabOpen: number;
 };
 
-export const getPreviewPosition = ({
+/**
+ * Build the animated style for the preview container view.
+ *
+ * When the navigator or addons panel is focused, the preview container is
+ * scaled down and translated to the left (or right) of the panel.
+ */
+export const getPreviewStyle = ({
   animatedValue,
   previewDimensions: { width: previewWidth, height: previewHeight },
-  slideBetweenAnimation,
   wide,
+  insets,
+  tabOpen,
+  lastTabOpen,
 }: PreviewPositionArgs) => {
-  const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
-  const translateX =
-    (previewWidth / 2 - (previewWidth * scale) / 2 - TRANSLATE_X_OFFSET) * RTL_SCALE;
-  const translateY = -(previewHeight / 2 - (previewHeight * scale) / 2 - TRANSLATE_Y_OFFSET);
+  const scale = (wide ? PREVIEW_SCALE_WIDE : PREVIEW_SCALE) * PREVIEW_SCALE_SHRINK;
+  const scaledPreviewWidth = previewWidth * scale;
+  const scaledPreviewHeight = previewHeight * scale;
+  // Horizontally center the scaled preview in the available space beside the panel.
+  const nonPanelWidth = previewWidth - panelWidth(previewWidth, wide);
+  const translateXOffset = (nonPanelWidth - scaledPreviewWidth) / 2;
+  const translateX = (previewWidth / 2 - (previewWidth * scale) / 2 - translateXOffset) * RTL_SCALE;
+  // Translate the preview to the top edge of the screen, move it down by the
+  // safe area inset, then by the preview Y offset.
+  const translateY =
+    -(previewHeight / 2 - scaledPreviewHeight / 2) + insets.top + TRANSLATE_Y_OFFSET;
+  // Is navigation moving from one panel to another, skipping preview?
+  const skipPreview = lastTabOpen !== PREVIEW && tabOpen !== PREVIEW;
 
   return {
     transform: [
@@ -86,27 +109,33 @@ export const getPreviewPosition = ({
       {
         translateY: animatedValue.interpolate({
           inputRange: [NAVIGATOR, PREVIEW, ADDONS],
-          outputRange: [translateY, slideBetweenAnimation ? translateY : 0, translateY],
+          outputRange: [translateY, skipPreview ? translateY : 0, translateY],
+        }),
+      },
+      {
+        scale: animatedValue.interpolate({
+          inputRange: [NAVIGATOR, PREVIEW, ADDONS],
+          outputRange: [scale, skipPreview ? scale : 1, scale],
         }),
       },
     ],
   };
 };
 
-export const getPreviewScale = (
-  animatedValue: Animated.Value,
-  slideBetweenAnimation: boolean,
-  wide: boolean
-) => {
-  const scale = wide ? PREVIEW_WIDE_SCREEN : PREVIEW_SCALE;
-  return {
-    transform: [
-      {
-        scale: animatedValue.interpolate({
-          inputRange: [NAVIGATOR, PREVIEW, ADDONS],
-          outputRange: [scale, slideBetweenAnimation ? scale : 1, scale],
-        }),
-      },
-    ],
-  };
-};
+/**
+ * Build the animated shadow style for the preview.
+ *
+ * When the navigator or addons panel are visible the scaled preview will have
+ * a shadow, and when going to the preview tab the shadow will be invisible.
+ */
+export const getPreviewShadowStyle = (animatedValue: Animated.Value) => ({
+  elevation: 8,
+  shadowColor: '#000',
+  shadowOpacity: animatedValue.interpolate({
+    inputRange: [NAVIGATOR, PREVIEW, ADDONS],
+    outputRange: [0.25, 0, 0.25],
+  }),
+  shadowRadius: 8,
+  shadowOffset: { width: 0, height: 0 },
+  overflow: 'visible' as const,
+});

--- a/app/react-native/src/preview/components/OnDeviceUI/navigation/Navigation.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { View, ViewStyle } from 'react-native';
+import { View, ViewProps, ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import GestureRecognizer from 'react-native-swipe-gestures';
 import Bar from './Bar';
@@ -15,6 +15,7 @@ interface Props {
   onChangeTab: (index: number) => void;
   isUIVisible: boolean;
   setIsUIVisible: Dispatch<SetStateAction<boolean>>;
+  onLayout: ViewProps['onLayout'];
 }
 
 const navStyle: ViewStyle = {
@@ -24,7 +25,7 @@ const navStyle: ViewStyle = {
   bottom: 0,
 };
 
-const Navigation = ({ tabOpen, onChangeTab, isUIVisible, setIsUIVisible }: Props) => {
+const Navigation = ({ tabOpen, onChangeTab, isUIVisible, setIsUIVisible, onLayout }: Props) => {
   const insets = useSafeAreaInsets();
 
   const handleToggleUI = () => {
@@ -44,7 +45,7 @@ const Navigation = ({ tabOpen, onChangeTab, isUIVisible, setIsUIVisible }: Props
   };
 
   return (
-    <View style={navStyle}>
+    <View style={navStyle} onLayout={onLayout}>
       {isUIVisible && (
         <GestureRecognizer
           onSwipeLeft={handleSwipeLeft}

--- a/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
+++ b/app/react-native/src/preview/components/StoryListView/StoryListView.tsx
@@ -3,13 +3,7 @@ import { addons, StoryKind } from '@storybook/addons';
 import { StoryIndex, StoryIndexEntry } from '@storybook/client-api';
 import Events from '@storybook/core-events';
 import React, { useMemo, useState } from 'react';
-import {
-  SectionList,
-  SectionListRenderItem,
-  StyleSheet,
-  TextInputProps,
-  View,
-} from 'react-native';
+import { SectionList, SectionListRenderItem, StyleSheet, TextInputProps, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { GridIcon, SearchIcon, StoryIcon } from '../Shared/icons';
 import { Header, Name } from '../Shared/text';
@@ -50,8 +44,8 @@ const SearchBar = (props: TextInputProps) => {
       <SearchIcon />
       <SearchInput
         {...props}
-        autoCapitalize='none'
-        autoComplete='off'
+        autoCapitalize="none"
+        autoComplete="off"
         autoCorrect={false}
         spellCheck={false}
         clearButtonMode="while-editing"
@@ -80,19 +74,7 @@ const HeaderContainer = styled.TouchableOpacity(
 );
 
 const StoryListContainer = styled.View(({ theme }) => ({
-  top: 0,
-  ...StyleSheet.absoluteFillObject,
-
-  // for this to work I need to get the top margin from safeareview context
-  // shadowColor: '#000',
-  // shadowOffset: {
-  //   width: 0,
-  //   height: 1,
-  // },
-  // shadowOpacity: 0.2,
-  // shadowRadius: 1.41,
-  // elevation: 2,
-
+  flex: 1,
   borderRightWidth: StyleSheet.hairlineWidth,
   borderRightColor: theme.borderColor,
   backgroundColor: theme.storyListBackgroundColor,
@@ -121,7 +103,11 @@ interface ListItemProps {
   isLastItem: boolean;
 }
 
-const ItemTouchable = styled.TouchableOpacity<{ selected: boolean, sectionSelected: boolean, isLastItem: boolean }>(
+const ItemTouchable = styled.TouchableOpacity<{
+  selected: boolean;
+  sectionSelected: boolean;
+  isLastItem: boolean;
+}>(
   {
     marginHorizontal: 6,
     padding: 6,
@@ -132,10 +118,10 @@ const ItemTouchable = styled.TouchableOpacity<{ selected: boolean, sectionSelect
   ({ selected, sectionSelected, isLastItem, theme }) => {
     return {
       backgroundColor: selected
-        ? (theme?.listItemActiveColor ?? '#1ea7fd')
+        ? theme?.listItemActiveColor ?? '#1ea7fd'
         : sectionSelected
-          ? theme?.sectionActiveColor
-          : undefined,
+        ? theme?.sectionActiveColor
+        : undefined,
       borderBottomLeftRadius: isLastItem ? 6 : undefined,
       borderBottomRightRadius: isLastItem ? 6 : undefined,
     };
@@ -195,14 +181,11 @@ const styles = StyleSheet.create({
   sectionListContentContainer: { paddingBottom: 6 },
 });
 
-const tabBarHeight = 40;
-
 function keyExtractor(item: any, index) {
   return item.id + index;
 }
 
 const StoryListView = ({ storyIndex }: Props) => {
-  const insets = useSafeAreaInsets();
   const originalData = useMemo(() => getStories(storyIndex), [storyIndex]);
   const [data, setData] = useState<DataItem[]>(originalData);
 
@@ -238,46 +221,45 @@ const StoryListView = ({ storyIndex }: Props) => {
     channel.emit(Events.SET_CURRENT_STORY, { storyId });
   };
 
-  const safeStyle = React.useMemo(() => {
-    return { flex: 1, marginTop: insets.top, paddingBottom: insets.bottom + tabBarHeight };
-  }, [insets]);
+  const renderItem: SectionListRenderItem<StoryIndexEntry, DataItem> = React.useCallback(
+    ({ item, index, section }) => {
+      return (
+        <ListItem
+          storyId={item.id}
+          title={item.name}
+          kind={item.title}
+          isLastItem={index === section.data.length - 1}
+          onPress={() => changeStory(item.id)}
+        />
+      );
+    },
+    []
+  );
 
-  const renderItem: SectionListRenderItem<StoryIndexEntry, DataItem> = React.useCallback(({item, index, section}) => {
-    return (
-      <ListItem
-        storyId={item.id}
-        title={item.name}
-        kind={item.title}
-        isLastItem={index === section.data.length - 1}
-        onPress={() => changeStory(item.id)}
-      />
-    );
-  }, []);
-
-  const renderSectionHeader = React.useCallback(({ section: { title, data } }) => (
-    <SectionHeader title={title} onPress={() => changeStory(data[0].id)} />
-  ), []);
+  const renderSectionHeader = React.useCallback(
+    ({ section: { title, data } }) => (
+      <SectionHeader title={title} onPress={() => changeStory(data[0].id)} />
+    ),
+    []
+  );
 
   return (
     <StoryListContainer>
-      <View style={safeStyle}>
-        <SearchBar
-          testID="Storybook.ListView.SearchBar"
-          onChangeText={handleChangeSearchText}
-          placeholder="Find by name"
-        />
-        <SectionList
-          // contentInset={{ bottom: insets.bottom, top: 0 }}
-          style={styles.sectionList}
-          contentContainerStyle={styles.sectionListContentContainer}
-          testID="Storybook.ListView"
-          renderItem={renderItem}
-          renderSectionHeader={renderSectionHeader}
-          keyExtractor={keyExtractor}
-          sections={data}
-          stickySectionHeadersEnabled={false}
-        />
-      </View>
+      <SearchBar
+        testID="Storybook.ListView.SearchBar"
+        onChangeText={handleChangeSearchText}
+        placeholder="Find by name"
+      />
+      <SectionList
+        style={styles.sectionList}
+        contentContainerStyle={styles.sectionListContentContainer}
+        testID="Storybook.ListView"
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        sections={data}
+        stickySectionHeadersEnabled={false}
+      />
     </StoryListContainer>
   );
 };

--- a/examples/native/components/SafeAreaExample/UsableArea.stories.tsx
+++ b/examples/native/components/SafeAreaExample/UsableArea.stories.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react-native';
+import { View, StyleSheet, Text } from 'react-native';
+
+const UsableAreaMeta: ComponentMeta<any> = {
+  title: 'Usable Area',
+};
+export default UsableAreaMeta;
+
+type UsableAreaStory = ComponentStory<any>;
+
+function UsableAreaContent() {
+  return (
+    <View
+      style={{
+        ...StyleSheet.absoluteFillObject,
+        borderWidth: 4,
+        borderColor: 'red',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Text>This box should reach all corners of the content area.</Text>
+    </View>
+  );
+}
+
+export const SafeArea: UsableAreaStory = () => <UsableAreaContent />;
+SafeArea.parameters = { noSafeArea: false };
+
+export const NoSafeArea: UsableAreaStory = () => <UsableAreaContent />;
+NoSafeArea.parameters = { noSafeArea: true };


### PR DESCRIPTION
Issue:

In stories with `noSafeArea: false` (the default), the available space for story content is cut off at the bottom (going below the navigation bar) even when hiding the navigation UI.

## What I did

I removed the `marginTop` adjustment in the preview area, this seems to not be necessary for `noSafeArea: false` or `noSafeArea: true` stories, the translate-Y adjustment is perfectly fine.

## How to test

I added a new "Usable area" story that has an absolute-filled box, all 4 borders of the box should always be visible and `noSafeArea` should dictate how much of the screen is allowed to be occupied by the story content.

| Before | After |
|--------|------|
| <img width="502" alt="image" src="https://user-images.githubusercontent.com/112166/220442400-50dda478-5067-4a0d-b3cf-90892d827400.png">            |  <img width="502" alt="image" src="https://user-images.githubusercontent.com/112166/220442067-a6d53c03-39ff-4c21-8014-075c1062c938.png"> |

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
