### PR TITLE
fix: StoryView was interfering with scroll gestures

### DIFF
--- a/app/react-native/src/preview/components/StoryView/StoryView.tsx
+++ b/app/react-native/src/preview/components/StoryView/StoryView.tsx
@@ -1,8 +1,24 @@
 import React from 'react';
 
-import { Text, TouchableWithoutFeedback, Keyboard } from 'react-native';
+import { Text, Keyboard } from 'react-native';
 import { useStoryContext } from '../../../hooks';
 import { Box } from '../Shared/layout';
+
+/**
+ * This is a handler for `onStartShouldSetResponder`, which dismisses the
+ * keyboard as a side effect but then responds with `false` to the responder
+ * system, so as not to start actually handling the touch.
+ *
+ * The objective here is to dismiss the keyboard when the story view is tapped,
+ * but in a way that won't interfere with presses or swipes. Using a
+ * `Touchable...` component as a wrapper will start to handle the touch, which
+ * will swallow swipe gestures that should have gone on to a child view, such
+ * as `ScrollView`.
+ */
+function dismissOnStartResponder() {
+  Keyboard.dismiss();
+  return false;
+}
 
 const StoryView = () => {
   const context = useStoryContext();
@@ -11,14 +27,10 @@ const StoryView = () => {
   if (context && context.unboundStoryFn) {
     const { unboundStoryFn: StoryComponent } = context;
 
-    // Wrapped in `TouchableWithoutFeedback` so that a tap in the story view,
-    // outside of something that handles the press, will dismiss the keyboard.
     return (
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <Box flex key={id} testID={id}>
-          {StoryComponent && <StoryComponent {...context} />}
-        </Box>
-      </TouchableWithoutFeedback>
+      <Box flex key={id} testID={id} onStartShouldSetResponder={dismissOnStartResponder}>
+        {StoryComponent && <StoryComponent {...context} />}
+      </Box>
     );
   }
 

--- a/examples/expo-example/components/InteractionExample/InteractionExample.stories.tsx
+++ b/examples/expo-example/components/InteractionExample/InteractionExample.stories.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react-native';
+import { View, ScrollView, Text, TextInput, TouchableOpacity } from 'react-native';
+
+export default {
+  title: 'Interaction Example',
+  parameters: {
+    notes: `
+Use these example to test that tapping the story view will dismiss the keyboard,
+but won't interfere with scrolling or other touch interactions.
+`,
+  },
+} as ComponentMeta<any>;
+
+type InteractionExampleStory = ComponentStory<any>;
+
+function ExampleItem({ children }) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        borderRadius: 8,
+        backgroundColor: '#dee2e3',
+        marginBottom: 8,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Text style={{ color: '#001a23' }}>{children}</Text>
+    </View>
+  );
+}
+
+function ExampleInput() {
+  return (
+    <TextInput
+      style={{
+        borderWidth: 1.25,
+        borderColor: '#a3c1e0',
+        marginBottom: 8,
+        borderRadius: 8,
+        height: 40,
+        paddingHorizontal: 8,
+      }}
+      placeholder="Type something"
+    />
+  );
+}
+
+export const Static: InteractionExampleStory = () => (
+  <>
+    <ExampleInput />
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>
+        Opening the keyboard and then tapping somewhere in a story view will dismiss the keyboard.
+      </Text>
+    </View>
+  </>
+);
+
+export const Touchable: InteractionExampleStory = () => {
+  const [count, increment] = React.useReducer((state) => state + 1, 0);
+  return (
+    <>
+      <ExampleInput />
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text>Pressed {count} time(s)</Text>
+        <TouchableOpacity
+          style={{
+            borderWidth: 1,
+            borderRadius: 8,
+            padding: 8,
+            marginVertical: 16,
+            borderColor: '#b2cbe6',
+            backgroundColor: '#dcebf9',
+          }}
+          onPress={() => increment()}
+        >
+          <Text>This button can be tapped without the story view interfering.</Text>
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+};
+
+export const Scrolling: InteractionExampleStory = () => (
+  <>
+    <ExampleInput />
+    <ScrollView>
+      <ExampleItem>This can scroll when the keyboard is closed.</ExampleItem>
+      <ExampleItem>And also when the keyboard is open.</ExampleItem>
+      {Array(25)
+        .fill(true)
+        .map((_ignored, idx) => (
+          <ExampleItem key={idx}>Item #{idx}</ExampleItem>
+        ))}
+    </ScrollView>
+  </>
+);


### PR DESCRIPTION
Some touch interactions, especially scrolling, were not working well after `StoryView` started wrapping its contents in `TouchableWithoutFeedback`.

## What I did

Switch out the use of `TouchableWithoutFeedback` and prefer to use [`onStartShouldSetResponder`](https://reactnative.dev/docs/view#onstartshouldsetresponder) to listen for touch interactions, dismiss the keyboard, and then decline to handle the touch interaction. This means that the interaction attempt is handed to the next component in the hierarchy to handle.

Unlike `Touchable...` which _wants_ to handle the interaction, and ends up interfering with interactions.

## How to test

There are a few new stories under the "Interaction Examples" section in the storybook. They all work now, but you can see the broken behaviour by making the following local modifications in `StoryView.tsx`:

- Remove `onStartShouldSetResponder={dismissOnStartResponder}`
- Wrap the story view content:
  ```
  <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
    <Box …>…</Box>
  </TouchableWithoutFeedback
  ```

Most of the interactions are unaffected, but the "Scrolling" story will not be scrollable unless the keyboard is open.

If you remove both the `TouchableWithoutFeedback` and the `onStartShouldSetResponder` prop, then the scrolling interaction views will dismiss the keyboard on tap, but the "Static" story won't.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
