### PR TITLE
fix: windows paths now generated correctly

### DIFF
--- a/app/react-native/scripts/loader.js
+++ b/app/react-native/scripts/loader.js
@@ -107,7 +107,12 @@ function writeRequires({ configPath, absolute = false }) {
         const absolutePath = absolute ? requirePath : path.resolve(configPath, requirePath);
         const pathRelativeToCwd = path.relative(cwd, absolutePath);
 
-        return `"./${pathRelativeToCwd}": require("${requirePath}")`;
+        const normalizePathForWindows = (str) =>
+          path.sep === '\\' ? str.replace(/\\/g, '/') : str;
+
+        return `"./${normalizePathForWindows(
+          pathRelativeToCwd
+        )}": require("${normalizePathForWindows(requirePath)}")`;
       });
     return [...acc, ...paths];
   }, []);


### PR DESCRIPTION
Issue: #444 

## What I did

normalise paths when running on windows

## How to test

Please explain how to test your changes and consider the following questions

- run the example app on windows

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
