### PR TITLE
fix: cast to string on select control

### DIFF
--- a/addons/ondevice-controls/src/types/Select.tsx
+++ b/addons/ondevice-controls/src/types/Select.tsx
@@ -66,14 +66,14 @@ const SelectType = ({ arg, onChange }: SelectProps) => {
     <View>
       <ModalPicker
         data={options}
-        initValue={value}
+        initValue={String(value)}
         onChange={(option) => onChange(option.key)}
         animationType="none"
         keyExtractor={({ key, label }) => `${label}-${key}`}
       >
         <Input
           editable={false}
-          value={selected}
+          value={String(selected)}
           autoCapitalize="none"
           underlineColorAndroid="transparent"
         />

--- a/examples/expo-example/components/ControlExamples/Reproductions/SelectWithNumber.stories.tsx
+++ b/examples/expo-example/components/ControlExamples/Reproductions/SelectWithNumber.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+
+import { MyButton } from './SelectWithNumber';
+
+export default {
+  component: MyButton,
+} as ComponentMeta<typeof MyButton>;
+
+export const Basic: ComponentStoryObj<typeof MyButton> = {
+  args: {},
+};

--- a/examples/expo-example/components/ControlExamples/Reproductions/SelectWithNumber.stories.tsx
+++ b/examples/expo-example/components/ControlExamples/Reproductions/SelectWithNumber.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 import { MyButton } from './SelectWithNumber';
 
 export default {
+  title: 'SelectWithNumber',
   component: MyButton,
 } as ComponentMeta<typeof MyButton>;
 

--- a/examples/expo-example/components/ControlExamples/Reproductions/SelectWithNumber.tsx
+++ b/examples/expo-example/components/ControlExamples/Reproductions/SelectWithNumber.tsx
@@ -1,0 +1,27 @@
+import { Text, TouchableOpacity, View } from 'react-native';
+import React from 'react';
+
+export type ButtonProps = {
+  number: keyof {
+    1: 'test';
+    2: 'test';
+    3: 'test';
+    4: 'test';
+    5: 'test';
+    6: 'test';
+    7: 'test';
+    8: 'test';
+    9: 'test';
+  };
+};
+
+export const MyButton = ({ number }: ButtonProps) => {
+  console.log(typeof number);
+  return (
+    <View>
+      <TouchableOpacity activeOpacity={0.8}>
+        <Text>{number}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};


### PR DESCRIPTION
Issue: #449

## What I did

cast the value to string when the control type is select
added a story to reproduce this at `examples/expo-example/components/ControlExamples/Reproductions/SelectWithNumber.stories.tsx`

## How to test



- run the example and update the number in "select with number"

