### PR TITLE
Fix missing icons on react-native < 0.71

### DIFF
--- a/app/react-native/src/preview/components/Shared/icons.tsx
+++ b/app/react-native/src/preview/components/Shared/icons.tsx
@@ -41,5 +41,14 @@ interface IconProps extends React.ComponentProps<typeof StyledImage> {
 
 export function Icon({ name, background = false, ...props }: IconProps) {
   const IconComponent = background ? StyledImageBackground : StyledImage;
-  return <IconComponent source={iconSources[name]} width={16} height={16} {...props} />;
+  return (
+    <IconComponent
+      source={{
+        ...iconSources[name],
+        width: 16,
+        height: 16,
+      }}
+      {...props}
+    />
+  );
 }


### PR DESCRIPTION
Issue:

`width` and `height` were only introduced as props on `Image` in react-native 0.71 (see eg [docs for 0.70](https://reactnative.dev/docs/0.70/image#imagesource)). Versions below this don't display the icons.

## What I did

Moved the dimensions to properties of the `source` prop

## How to test

Check the expo-example visually then struggle to downgrade the react-native version (I didn't manage it!)

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
