### PR TITLE
docs: downgrading setup intructions to stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx react-native init MyApp --template react-native-template-storybook
 Run init to setup your project with all the dependencies and configuration files:
 
 ```sh
-npx sb@next init --type react_native
+npx sb init --type react_native
 ```
 
 The only thing left to do is return Storybook's UI in your app entry point (such as `App.js`) like this:


### PR DESCRIPTION
Issue: --

## What I did

As a developer
I wanted to install storybook to an existing expo project
So that i can sparks joy in my UI

## Why this PR?

Running the last version will install the last version `@next`

```
❯ npx sb@next init --type react_native
Need to install the following packages:
  sb@7.1.0-alpha.29
Ok to proceed? (y) y
```

this can lead to random issues like #473 

That's why we could ask to install the last stable version