### PR TITLE
docs: migrate away from legacy expo-cli

### DIFF
--- a/MANUAL_SETUP.md
+++ b/MANUAL_SETUP.md
@@ -7,7 +7,7 @@ Before getting into the guide consider using a template for a simpler setup proc
 For expo you can use this [template](https://github.com/dannyhw/expo-template-storybook) with the following command
 
 ```sh
-expo init --template expo-template-storybook AwesomeStorybook
+npx create-expo-app --template expo-template-storybook AwesomeStorybook
 ```
 
 For react native cli you can use this [template](https://github.com/dannyhw/react-native-template-storybook)


### PR DESCRIPTION
Issue:

Avoid the warning error

<img width="588" alt="image" src="https://github.com/storybookjs/react-native/assets/360936/e922ce41-bcf4-4214-8118-ac6944abd5b9">

## What I did

drop `expo-cli`

## How to test

run `npx create-expo-app --template expo-template-storybook AwesomeStorybook`