### PR TITLE
make storage configurable

### DIFF
--- a/examples/expo-example/package.json
+++ b/examples/expo-example/package.json
@@ -15,7 +15,6 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/datetimepicker": "7.2.0",
     "@react-native-community/slider": "4.4.2",
     "@storybook/addon-actions": "^6.5.14",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -81,7 +81,6 @@
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "@react-native-async-storage/async-storage": ">=1",
     "react": "*",
     "react-native": ">=0.57.0",
     "react-native-safe-area-context": "*"


### PR DESCRIPTION
Issue:

I don't want to install and maintain an additional dependency like `@react-native-async-storage/async-storage` when I use another storage library or don't use one at all.

So the storage should be configurable instead hardcoded.

## What I did

I removed `@react-native-async-storage/async-storage` completely as dependency and added an `storage`-option to the params parameter of `getStorybookUi`. So if you want to use AsyncStorage you need to add it like the following example shows:

```tsx
import AsyncStorage from '@react-native-async-storage/async-storage';

const StorybookUIRoot = getStorybookUI({
  storage: {
    getItem: AsyncStore.getItem,
    setItem: AsyncStore.setItem
  }
})
```

Or if you use `react-native-mmkv`:

```tsx
import {MMKV} from 'react-native-mmkv'

const storage = new MMKV()

const StorybookUIRoot = getStorybookUI({
  storage: {
    setItem: async (key, data) => storage.set(key, data),
    getItem: async (key) => storage.getString(key) ?? null,
  }
})
```

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.


Don't have the time at the moment to update the documentation, but I will later.