### PR TITLE
feat(react-native-server): add  flag to open storybook in the browser

### DIFF
--- a/packages/react-native-server/src/server/cli.js
+++ b/packages/react-native-server/src/server/cli.js
@@ -25,6 +25,7 @@ function getCli() {
     .option('--ssl-key <key>', 'Provide an SSL key. (Required with --https)')
     .option('--smoke-test', 'Exit after successful start')
     .option('--ci', "CI mode (skip interactive prompts, don't open browser)")
+    .option('--open', "Whether to open Storybook automatically in the browser")
     .option('--quiet', 'Suppress verbose build output');
 
   program.parse();


### PR DESCRIPTION
Issue: none

## What I did
This is a PR to enable Storybook CLI's `--open` flag on react-native-server as well.
The `--open` flag will cause the browser to automatically open web UI when start Storybook Server.

In Storybook 6, Storybook Server no longer opens a browser on startup by default.
At that time, opening the browser was suppressed by adding the `--no-open` flag, but now it seems that the browser will not open unless the `--open` flag is specified.

https://github.com/storybookjs/storybook/blob/7db13fface8f05b870a16b90694a840785830f7e/lib/core-common/src/types.ts#L201
https://github.com/storybookjs/storybook/issues/6201#issuecomment-891120814
https://github.com/storybookjs/storybook/blob/7db13fface8f05b870a16b90694a840785830f7e/lib/core-server/src/dev-server.ts#L177-L180


## How to test
Add the `--open` flag to the `start-server` command in `expo-example`.
