### PR TITLE
fix: wrong ids created for multiple configs with titlePrefix (v7)

### DIFF
--- a/examples/expo-example/.storybook/main.js
+++ b/examples/expo-example/.storybook/main.js
@@ -1,7 +1,11 @@
 module.exports = {
   stories: [
     '../components/**/*.stories.?(ts|tsx|js|jsx)',
-    '../other_components/AnotherButton/AnotherButton.stories.tsx',
+    {
+      directory: '../other_components',
+      files: '**/*.stories.?(ts|tsx|js|jsx)',
+      titlePrefix: 'OtherComponents',
+    },
   ],
   addons: [
     '@storybook/addon-ondevice-notes',

--- a/examples/expo-example/.storybook/storybook.requires.ts
+++ b/examples/expo-example/.storybook/storybook.requires.ts
@@ -23,15 +23,16 @@ const normalizedStories = [
     ),
   },
   {
-    titlePrefix: "",
-    directory: "./other_components/AnotherButton",
-    files: "AnotherButton.stories.tsx",
-    importPathMatcher: /^\.[\\/](?:AnotherButton\.stories\.tsx)$/,
+    titlePrefix: "OtherComponents",
+    directory: "./other_components",
+    files: "**/*.stories.?(ts|tsx|js|jsx)",
+    importPathMatcher:
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/,
     // @ts-ignore
     req: require.context(
-      "../other_components/AnotherButton",
-      false,
-      /^\.[\\/](?:AnotherButton\.stories\.tsx)$/
+      "../other_components",
+      true,
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
     ),
   },
 ];

--- a/examples/expo-example/other_components/TestCase/TestCase.stories.tsx
+++ b/examples/expo-example/other_components/TestCase/TestCase.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Text } from 'react-native';
+
+const TestCase = () => {
+  return <Text>Testing story globs and nested stories</Text>;
+};
+
+export default {
+  title: 'TestCase1',
+  component: TestCase,
+} satisfies Meta<typeof TestCase>;
+
+export const Basic: StoryObj<typeof TestCase> = {
+  args: {},
+};

--- a/examples/expo-example/other_components/TestCase2/TestCase2.stories.tsx
+++ b/examples/expo-example/other_components/TestCase2/TestCase2.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Text } from 'react-native';
+
+const TestCase2 = () => {
+  return <Text>Testing story globs and nested stories</Text>;
+};
+
+export default {
+  title: 'TestCase2',
+  component: TestCase2,
+} satisfies Meta<typeof TestCase2>;
+
+export const Basic: StoryObj<typeof TestCase2> = {
+  args: {},
+};

--- a/packages/react-native/src/Start.tsx
+++ b/packages/react-native/src/Start.tsx
@@ -1,5 +1,9 @@
 import { toId, storyNameFromExport } from '@storybook/csf';
-import { addons as previewAddons, composeConfigs, userOrAutoTitle } from '@storybook/preview-api';
+import {
+  addons as previewAddons,
+  composeConfigs,
+  userOrAutoTitleFromSpecifier,
+} from '@storybook/preview-api';
 import { addons as managerAddons } from '@storybook/manager-api';
 // NOTE this really should be exported from preview-api, but it's not
 import { PreviewWithSelection } from '@storybook/preview-api/dist/preview-web';
@@ -20,8 +24,12 @@ export function prepareStories({
 
   let importMap = {};
 
-  const makeTitle = (fileName: string, userTitle: string) => {
-    const title = userOrAutoTitle(fileName, storyEntries, userTitle);
+  const makeTitle = (
+    fileName: string,
+    specifier: NormalizedStoriesSpecifier,
+    userTitle: string
+  ) => {
+    const title = userOrAutoTitleFromSpecifier(fileName, specifier, userTitle);
 
     if (title) {
       return title.replace('./', '');
@@ -39,7 +47,8 @@ export function prepareStories({
     }
   };
 
-  storyEntries.forEach(({ req, directory: root }) => {
+  storyEntries.forEach((specifier) => {
+    const { req, directory: root } = specifier;
     req.keys().forEach((filename: string) => {
       try {
         // console.log('req', req.resolve(filename));
@@ -56,7 +65,8 @@ export function prepareStories({
 
           //FIXME: autotitle
           const name = storyNameFromExport(key);
-          const title = makeTitle(filename, meta.title);
+          const title = makeTitle(filename, specifier, meta.title);
+
           if (title) {
             const id = toId(title, name);
 


### PR DESCRIPTION
Issue: As mentioned https://github.com/storybookjs/react-native/pull/502#issuecomment-1897160086

## What I did

Generate title from individual specifiers

## How to test

Try against repro at https://github.com/stevoland/react-native/commit/a76f075371b28e266dc4a21a2d35b82f99f2b7a0


- Does this need a new example in examples/expo-example? No
- Does this need an update to the documentation? No
