### PR TITLE
Failing case for render error in ondevice addons with many stories (v7)

### DIFF
--- a/examples/expo-example/.storybook/main.js
+++ b/examples/expo-example/.storybook/main.js
@@ -6,6 +6,11 @@ module.exports = {
       files: '**/*.stories.?(ts|tsx|js|jsx)',
       titlePrefix: 'OtherComponents',
     },
+    {
+      directory: '../many_components',
+      files: '**/*.?(ts|tsx|js|jsx)',
+      titlePrefix: 'ManyComponents',
+    },
     // {
     //   directory: '../other_components',
     //   files: '**/*.storiesof.?(ts|tsx|js|jsx)',

--- a/examples/expo-example/.storybook/storybook.requires.ts
+++ b/examples/expo-example/.storybook/storybook.requires.ts
@@ -35,6 +35,19 @@ const normalizedStories = [
       /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.(?:ts|tsx|js|jsx)?)$/
     ),
   },
+  {
+    titlePrefix: "ManyComponents",
+    directory: "./many_components",
+    files: "**/*.?(ts|tsx|js|jsx)",
+    importPathMatcher:
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.(?:ts|tsx|js|jsx)?)$/,
+    // @ts-ignore
+    req: require.context(
+      "../many_components",
+      true,
+      /^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.(?:ts|tsx|js|jsx)?)$/
+    ),
+  },
 ];
 
 // @ts-ignore

--- a/examples/expo-example/many_components/Component0.stories.tsx
+++ b/examples/expo-example/many_components/Component0.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component1.stories.tsx
+++ b/examples/expo-example/many_components/Component1.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component10.stories.tsx
+++ b/examples/expo-example/many_components/Component10.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component11.stories.tsx
+++ b/examples/expo-example/many_components/Component11.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component12.stories.tsx
+++ b/examples/expo-example/many_components/Component12.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component13.stories.tsx
+++ b/examples/expo-example/many_components/Component13.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component14.stories.tsx
+++ b/examples/expo-example/many_components/Component14.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component15.stories.tsx
+++ b/examples/expo-example/many_components/Component15.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component16.stories.tsx
+++ b/examples/expo-example/many_components/Component16.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component17.stories.tsx
+++ b/examples/expo-example/many_components/Component17.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component18.stories.tsx
+++ b/examples/expo-example/many_components/Component18.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component19.stories.tsx
+++ b/examples/expo-example/many_components/Component19.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component2.stories.tsx
+++ b/examples/expo-example/many_components/Component2.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component20.stories.tsx
+++ b/examples/expo-example/many_components/Component20.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component21.stories.tsx
+++ b/examples/expo-example/many_components/Component21.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component22.stories.tsx
+++ b/examples/expo-example/many_components/Component22.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component23.stories.tsx
+++ b/examples/expo-example/many_components/Component23.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component24.stories.tsx
+++ b/examples/expo-example/many_components/Component24.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component25.stories.tsx
+++ b/examples/expo-example/many_components/Component25.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component26.stories.tsx
+++ b/examples/expo-example/many_components/Component26.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component27.stories.tsx
+++ b/examples/expo-example/many_components/Component27.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component28.stories.tsx
+++ b/examples/expo-example/many_components/Component28.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component29.stories.tsx
+++ b/examples/expo-example/many_components/Component29.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component3.stories.tsx
+++ b/examples/expo-example/many_components/Component3.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component30.stories.tsx
+++ b/examples/expo-example/many_components/Component30.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component31.stories.tsx
+++ b/examples/expo-example/many_components/Component31.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component32.stories.tsx
+++ b/examples/expo-example/many_components/Component32.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component33.stories.tsx
+++ b/examples/expo-example/many_components/Component33.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component34.stories.tsx
+++ b/examples/expo-example/many_components/Component34.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component35.stories.tsx
+++ b/examples/expo-example/many_components/Component35.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component36.stories.tsx
+++ b/examples/expo-example/many_components/Component36.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component37.stories.tsx
+++ b/examples/expo-example/many_components/Component37.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component38.stories.tsx
+++ b/examples/expo-example/many_components/Component38.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component39.stories.tsx
+++ b/examples/expo-example/many_components/Component39.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component4.stories.tsx
+++ b/examples/expo-example/many_components/Component4.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component40.stories.tsx
+++ b/examples/expo-example/many_components/Component40.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component41.stories.tsx
+++ b/examples/expo-example/many_components/Component41.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component42.stories.tsx
+++ b/examples/expo-example/many_components/Component42.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component43.stories.tsx
+++ b/examples/expo-example/many_components/Component43.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component44.stories.tsx
+++ b/examples/expo-example/many_components/Component44.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component45.stories.tsx
+++ b/examples/expo-example/many_components/Component45.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component46.stories.tsx
+++ b/examples/expo-example/many_components/Component46.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component47.stories.tsx
+++ b/examples/expo-example/many_components/Component47.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component48.stories.tsx
+++ b/examples/expo-example/many_components/Component48.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component49.stories.tsx
+++ b/examples/expo-example/many_components/Component49.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component5.stories.tsx
+++ b/examples/expo-example/many_components/Component5.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component50.stories.tsx
+++ b/examples/expo-example/many_components/Component50.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component6.stories.tsx
+++ b/examples/expo-example/many_components/Component6.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component7.stories.tsx
+++ b/examples/expo-example/many_components/Component7.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component8.stories.tsx
+++ b/examples/expo-example/many_components/Component8.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};

--- a/examples/expo-example/many_components/Component9.stories.tsx
+++ b/examples/expo-example/many_components/Component9.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+const Component = () => null;
+
+const meta: Meta<typeof Component> = {
+  component: Component,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Story1: Story = {};
+export const Story2: Story = {};
+export const Story3: Story = {};
+export const Story4: Story = {};
+export const Story5: Story = {};
+export const Story6: Story = {};
+export const Story7: Story = {};
+export const Story8: Story = {};
+export const Story9: Story = {};
+export const Story10: Story = {};
+export const Story11: Story = {};
+export const Story12: Story = {};
+export const Story13: Story = {};
+export const Story14: Story = {};
+export const Story15: Story = {};
+export const Story16: Story = {};
+export const Story17: Story = {};
+export const Story18: Story = {};
+export const Story19: Story = {};
+export const Story21: Story = {};
+export const Story22: Story = {};
+export const Story23: Story = {};
+export const Story24: Story = {};
+export const Story25: Story = {};
+export const Story26: Story = {};
+export const Story27: Story = {};
+export const Story28: Story = {};
+export const Story29: Story = {};
+export const Story30: Story = {};
+export const Story31: Story = {};
+export const Story32: Story = {};
+export const Story33: Story = {};
+export const Story34: Story = {};
+export const Story35: Story = {};
+export const Story36: Story = {};
+export const Story37: Story = {};
+export const Story38: Story = {};
+export const Story39: Story = {};
+export const Story40: Story = {};
+export const Story41: Story = {};
+export const Story42: Story = {};
+export const Story43: Story = {};
+export const Story44: Story = {};
+export const Story45: Story = {};
+export const Story46: Story = {};
+export const Story47: Story = {};
+export const Story48: Story = {};
+export const Story49: Story = {};


### PR DESCRIPTION
Issue:

Large storybook hits render error in ondevice addon panels eg

```
Error: Cannot call fromId/raw() unless you call cacheAllCSFFiles() first.

This error is located at:
    in Notes (created by Wrapper)
    in RCTScrollContentView (at ScrollView.js:1732)
```

I think a guard something along these lines is required https://github.com/reg-viz/storycap/pull/605/files#diff-bad46b72635dc4ead145dcbaaf545cd2ecd5695f8d83271cf3327237d5368060

## What I did

Hit this error with my actual project. Took a while to track it down to the size of the store.

## How to test

Run storybook dev, go to controls/notes/backgrounds panel on device

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
