### PR TITLE
bug: on Windows path with back slash removed after formatting with prettier

### DIFF
--- a/packages/react-native/scripts/generate.js
+++ b/packages/react-native/scripts/generate.js
@@ -36,7 +36,10 @@ function generate({ configPath, absolute = false, useJs = false }) {
 
     const { path: p, recursive: r, match: m } = toRequireContext(specifier);
 
-    const pathToStory = ensureRelativePathHasDot(path.relative(configPath, p));
+    const pathToStory = ensureRelativePathHasDot(
+      path.relative(configPath, p).split(path.sep).join(path.posix.sep)
+    );
+
     return `{
       titlePrefix: "${specifier.titlePrefix}",
       directory: "${specifier.directory}",

--- a/packages/react-native/scripts/generate.js
+++ b/packages/react-native/scripts/generate.js
@@ -29,7 +29,6 @@ function generate({ configPath, absolute = false, useJs = false }) {
     workingDir: cwd,
   });
 
-  // TODO refactor contexts and normalized stories to be one thing
   const normalizedStories = storiesSpecifiers.map((specifier) => {
     // TODO why????
     const reg = globToRegexp(`./${specifier.files}`);

--- a/packages/react-native/scripts/generate.js
+++ b/packages/react-native/scripts/generate.js
@@ -36,10 +36,7 @@ function generate({ configPath, absolute = false, useJs = false }) {
 
     const { path: p, recursive: r, match: m } = toRequireContext(specifier);
 
-    const pathToStory = ensureRelativePathHasDot(
-      path.relative(configPath, p).split(path.sep).join(path.posix.sep)
-    );
-
+    const pathToStory = ensureRelativePathHasDot(path.posix.relative(configPath, p));
     return `{
       titlePrefix: "${specifier.titlePrefix}",
       directory: "${specifier.directory}",


### PR DESCRIPTION
Issue:

## What I did

I executed `yarn storybook-generate` which generated a new storybook.requires.ts file with an incorrect path (this happens on Windows).

The backslash in a path is being removed by prettier when it formats the fileContent string (`scripts/generate.js`)

## How to test

1. You need to execute this on a Windows machine

2. Change the story path `../src/components/**/*.stories.?(ts|tsx|js|jsx)`:

![image](https://github.com/storybookjs/react-native/assets/1058337/0840459b-bb78-41f3-8c0e-410f6103217c)

3. Run `yarn storybook-generate`

4. The generated storybook.requires.ts file looks like this:

![image](https://github.com/storybookjs/react-native/assets/1058337/1ce9835f-129a-4caa-8daf-64b5fb1ebc61)

5. Due to this issue Storybook can't find any stories.

6. With the fix proposed in this PR you can correct the path resulting into:

![image](https://github.com/storybookjs/react-native/assets/1058337/32967047-b351-4307-888a-fb42107f4185)


<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
