### PR TITLE
fix: stricter types

### DIFF
--- a/examples/expo-example/App.test.tsx
+++ b/examples/expo-example/App.test.tsx
@@ -6,7 +6,7 @@ import App from './App';
 describe('<App />', () => {
   it('has 1 child', () => {
     const tree = renderer.create(<App />).toJSON();
-    if (!Array.isArray(tree) && tree.children) {
+    if (!Array.isArray(tree) && tree?.children) {
       expect(tree.children.length).toBe(1);
     } else {
       throw new Error('App has no children');

--- a/examples/expo-example/tsconfig.json
+++ b/examples/expo-example/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "skipLibCheck": true,
     "lib": ["es6"],
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "strict": true
   },
-  "extends": "expo/tsconfig.base"
+  "extends": "expo/tsconfig.base",
+  "include": ["./.storybook/", "./.storybook-web/", "./*"]
 }

--- a/packages/react-native/src/Start.tsx
+++ b/packages/react-native/src/Start.tsx
@@ -10,19 +10,19 @@ import { PreviewWithSelection } from '@storybook/preview-api/dist/preview-web';
 import { createBrowserChannel } from '@storybook/channels';
 import { View } from './View';
 import type { ReactRenderer } from '@storybook/react';
-import type { NormalizedStoriesSpecifier } from '@storybook/types';
+import type { NormalizedStoriesSpecifier, StoryIndex } from '@storybook/types';
 
 export function prepareStories({
   storyEntries,
 }: {
   storyEntries: Array<NormalizedStoriesSpecifier & { req: any }>;
 }) {
-  let index = {
+  let index: StoryIndex = {
     v: 4,
     entries: {},
   };
 
-  let importMap = {};
+  let importMap: Record<string, any> = {};
 
   const makeTitle = (
     fileName: string,


### PR DESCRIPTION
Issue:

## What I did

fixes ts error when strict checking due to missing type on the import map

error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
