### PR TITLE
automatically strip play functions for react-native runtime

### DIFF
--- a/packages/react-native/src/Start.tsx
+++ b/packages/react-native/src/Start.tsx
@@ -79,7 +79,23 @@ export function prepareStories({
               tags: ['story'],
             };
 
-            importMap[`${root}/${filename.substring(2)}`] = req(filename);
+            const importedStories = req(filename);
+            const stories = Object.entries(importedStories).reduce(
+              (carry, [storyKey, story]: [string, Readonly<Record<string, unknown>>]) => {
+                if (story.play) {
+                  // play functions are not supported on native. Instead of requiring consumers to
+                  // guard their play functions with platform checks, we automatically strip any
+                  // stories of their play functions for them.
+                  carry[storyKey] = { ...story, play: undefined };
+                } else {
+                  carry[storyKey] = story;
+                }
+                return carry;
+              },
+              {}
+            );
+
+            importMap[`${root}/${filename.substring(2)}`] = stories;
           } else {
             console.log(`Unexpected error while loading ${filename}: could not find title`);
           }


### PR DESCRIPTION
Issue:

## What I did

Play functions are not supported on native. Instead of requiring consumers to guard their play functions with platform checks, we automatically strip any stories of their play functions for them.

## How to test

This PR doesn't fully make writing play functions compatible with @storybook/react-native. See https://discord.com/channels/486522875931656193/490822534233849873/1233464353907540081.

I've worked around the build issue with the following metro config for now which is a bit hacky

```
      resolveRequest: function (context, moduleName, platform) {
        if (moduleName === 'os' || moduleName === 'tty') {
          return context.resolveRequest(context, 'lodash/noop', platform);
        }
```

I don't think it yet makes sense to add an example test showing that the play function is stripped from a story.

Please explain how to test your changes and consider the following questions.

- Does this need a new example in examples/expo-example? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
