### PR TITLE
darkmode support

### DIFF
--- a/packages/ondevice-notes/src/components/Notes.tsx
+++ b/packages/ondevice-notes/src/components/Notes.tsx
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 const darkModeMarkdownStyles = {
   body: {
-    backgroundColor: 'black',
+    color: 'white',
   },
   hr: {
     backgroundColor: 'white',

--- a/packages/ondevice-notes/src/components/Notes.tsx
+++ b/packages/ondevice-notes/src/components/Notes.tsx
@@ -1,6 +1,6 @@
 import { SET_CURRENT_STORY } from '@storybook/core-events';
 import { useEffect, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Appearance, StyleSheet, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 
 import { RNAddonApi, StoryFromId } from '../register';
@@ -45,12 +45,13 @@ export const Notes = ({ active, api }: NotesProps) => {
 
   const textAfterFormatted: string = text ? text.trim() : '';
 
+  const markdownStyles = Appearance.getColorScheme() === "dark" ? darkModeMarkdownStyles : {};
   return (
     <View style={styles.container}>
       {textAfterFormatted && (
         <ErrorBoundary>
           {/* @ts-ignore has the wrong types */}
-          <Markdown>{textAfterFormatted}</Markdown>
+          <Markdown style={markdownStyles}>{textAfterFormatted}</Markdown>
         </ErrorBoundary>
       )}
     </View>
@@ -60,3 +61,24 @@ export const Notes = ({ active, api }: NotesProps) => {
 const styles = StyleSheet.create({
   container: { flex: 1 },
 });
+
+const darkModeMarkdownStyles = {
+  body: {
+    backgroundColor: 'black',
+  },
+  hr: {
+    backgroundColor: 'white',
+  },
+  blockquote: {
+    borderColor: 'white',
+  },
+  table: {
+    borderColor: 'white',
+  },
+  tr: {
+    borderColor: 'white',
+  },
+  blocklink: {
+    borderColor: 'white',
+  },
+};


### PR DESCRIPTION
Issue: add dark mode support to Notes

## What I did

Set the dark mode style if it is dark mode

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
