### PR TITLE
Use theme to populate the markdown styles

### DIFF
--- a/packages/ondevice-notes/src/components/Notes.tsx
+++ b/packages/ondevice-notes/src/components/Notes.tsx
@@ -36,6 +36,43 @@ export const Notes = ({ active, api }: NotesProps) => {
     return () => channel.off(SET_CURRENT_STORY, handleSetCurrentStory);
   }, [api, active]);
 
+  const themedMarkdownStyles = useMemo(
+    () => ({
+      body: {
+        color: theme.color.defaultText,
+      },
+      hr: {
+        backgroundColor: theme.color.defaultText,
+      },
+      table: {
+        borderColor: theme.color.defaultText,
+      },
+      tr: {
+        borderColor: theme.color.defaultText,
+      },
+      blocklink: {
+        borderColor: theme.color.defaultText,
+      },
+      code_inline: {
+        color: theme.color.defaultText,
+        backgroundColor: theme.background.app,
+      },
+      code_block: {
+        color: theme.color.defaultText,
+        backgroundColor: theme.background.app,
+      },
+      fence: {
+        color: theme.color.defaultText,
+        backgroundColor: theme.background.app,
+      },
+      blockquote: {
+        borderColor: theme.color.defaultText,
+        backgroundColor: theme.background.app,
+      },
+    }),
+    [theme.color.defaultText, theme.background.app]
+  );
+
   if (!active || !story) {
     return null;
   }
@@ -47,36 +84,12 @@ export const Notes = ({ active, api }: NotesProps) => {
 
   const textAfterFormatted: string = text ? text.trim() : '';
 
-  const themedMarkdownStyles = useMemo(
-    () => ({
-      body: {
-        color: theme.color.defaultText,
-      },
-      hr: {
-        backgroundColor: theme.color.defaultText,
-      },
-      blockquote: {
-        borderColor: theme.color.defaultText,
-      },
-      table: {
-        borderColor: theme.color.defaultText,
-      },
-      tr: {
-        borderColor: theme.color.defaultText,
-      },
-      blocklink: {
-        borderColor: theme.color.defaultText,
-      }
-    }),
-    [theme.color.defaultText]);
   return (
     <View style={styles.container}>
       {textAfterFormatted && (
         <ErrorBoundary>
           {/* @ts-ignore has the wrong types */}
-          <Markdown style={themedMarkdownStyles}>
-            {textAfterFormatted}
-          </Markdown>
+          <Markdown style={themedMarkdownStyles}>{textAfterFormatted}</Markdown>
         </ErrorBoundary>
       )}
     </View>
@@ -86,4 +99,3 @@ export const Notes = ({ active, api }: NotesProps) => {
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 10 },
 });
-

--- a/packages/ondevice-notes/src/components/Notes.tsx
+++ b/packages/ondevice-notes/src/components/Notes.tsx
@@ -48,7 +48,7 @@ export const Notes = ({ active, api }: NotesProps) => {
   const textAfterFormatted: string = text ? text.trim() : '';
 
   const themedMarkdownStyles = useMemo(
-    ()=>({
+    () => ({
       body: {
         color: theme.color.defaultText,
       },

--- a/packages/ondevice-notes/src/components/Notes.tsx
+++ b/packages/ondevice-notes/src/components/Notes.tsx
@@ -1,5 +1,5 @@
 import { SET_CURRENT_STORY } from '@storybook/core/core-events';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 
@@ -47,12 +47,34 @@ export const Notes = ({ active, api }: NotesProps) => {
 
   const textAfterFormatted: string = text ? text.trim() : '';
 
+  const themedMarkdownStyles = useMemo(
+    ()=>({
+      body: {
+        color: theme.color.defaultText,
+      },
+      hr: {
+        backgroundColor: theme.color.defaultText,
+      },
+      blockquote: {
+        borderColor: theme.color.defaultText,
+      },
+      table: {
+        borderColor: theme.color.defaultText,
+      },
+      tr: {
+        borderColor: theme.color.defaultText,
+      },
+      blocklink: {
+        borderColor: theme.color.defaultText,
+      }
+    }),
+    [theme.color.defaultText]);
   return (
     <View style={styles.container}>
       {textAfterFormatted && (
         <ErrorBoundary>
           {/* @ts-ignore has the wrong types */}
-          <Markdown style={{ body: { color: theme.color.defaultText } }}>
+          <Markdown style={themedMarkdownStyles}>
             {textAfterFormatted}
           </Markdown>
         </ErrorBoundary>
@@ -64,3 +86,4 @@ export const Notes = ({ active, api }: NotesProps) => {
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 10 },
 });
+


### PR DESCRIPTION
Issue: only the text was converted to the theme color, this ensures all other elements are switched to the theme color

## What I did

useMemo against the theme default color to create a markdown stylesheet and applied that to the markdown element

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
