### PR TITLE
fix: overflowing story content overlaps sidebar

### DIFF
--- a/packages/react-native-ui/src/Layout.stories.tsx
+++ b/packages/react-native-ui/src/Layout.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Layout } from './Layout';
 import { mockDataset } from './mockdata';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import { LayoutProvider } from './LayoutProvider';
 
 const meta = {
   title: 'components/Layout',
@@ -12,7 +13,9 @@ const meta = {
     (Story) => (
       <GestureHandlerRootView style={{ flex: 1 }}>
         <BottomSheetModalProvider>
-          <Story />
+          <LayoutProvider>
+            <Story />
+          </LayoutProvider>
         </BottomSheetModalProvider>
       </GestureHandlerRootView>
     ),
@@ -26,6 +29,47 @@ type Story = StoryObj<typeof meta>;
 export const Basic: Story = {
   args: {
     children: <Text>Testing</Text>,
+    //@ts-ignore
+    storyHash: mockDataset.withRoot,
+    storyId: 'emails-buildnotification--with-changes',
+  },
+};
+
+export const OverflowSidebarExample: Story = {
+  args: {
+    children: (
+      <View
+        style={{
+          width: '100%',
+          backgroundColor: 'lightgreen',
+          alignItems: 'flex-end',
+          left: '-50%',
+        }}
+      >
+        <Text style={{ width: '50%', textAlign: 'right' }}>
+          This box should not overflow the side navigation in desktop mode
+        </Text>
+      </View>
+    ),
+    //@ts-ignore
+    storyHash: mockDataset.withRoot,
+    storyId: 'emails-buildnotification--with-changes',
+  },
+};
+
+export const OverflowAddonsExample: Story = {
+  args: {
+    children: (
+      <View
+        style={{
+          height: '100%',
+          backgroundColor: 'lightgreen',
+          bottom: '-50%',
+        }}
+      >
+        <Text style={{ height: '50%' }}>This box should not overflow the addons panel</Text>
+      </View>
+    ),
     //@ts-ignore
     storyHash: mockDataset.withRoot,
     storyId: 'emails-buildnotification--with-changes',

--- a/packages/react-native-ui/src/Layout.tsx
+++ b/packages/react-native-ui/src/Layout.tsx
@@ -104,8 +104,8 @@ export const Layout = ({
           )}
         </View>
 
-        <View style={{ flex: 1, overflow: 'hidden' }}>
-          <View style={{ flex: 1 }}>{children}</View>
+        <View style={{ flex: 1 }}>
+          <View style={{ flex: 1, overflow: 'hidden' }}>{children}</View>
 
           <View
             style={{

--- a/packages/react-native-ui/src/Layout.tsx
+++ b/packages/react-native-ui/src/Layout.tsx
@@ -104,7 +104,7 @@ export const Layout = ({
           )}
         </View>
 
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1, overflow: 'hidden' }}>
           <View style={{ flex: 1 }}>{children}</View>
 
           <View

--- a/packages/react-native-ui/src/Layout.tsx
+++ b/packages/react-native-ui/src/Layout.tsx
@@ -133,7 +133,7 @@ export const Layout = ({
 
   return (
     <View style={{ flex: 1, paddingTop: insets.top, backgroundColor: theme.background.content }}>
-      <View style={{ flex: 1 }}>{children}</View>
+      <View style={{ flex: 1, overflow: 'hidden' }}>{children}</View>
 
       <MobileMenuDrawer ref={mobileMenuDrawerRef} onStateChange={setDrawerOpen}>
         <View style={{ paddingLeft: 16, paddingTop: 4, paddingBottom: 4 }}>

--- a/packages/react-native/src/components/StoryView/StoryView.tsx
+++ b/packages/react-native/src/components/StoryView/StoryView.tsx
@@ -37,7 +37,7 @@ const StoryView = () => {
 
     return (
       <View
-        style={{ flex: 1, backgroundColor: theme.background?.content }}
+        style={{ flex: 1, backgroundColor: theme.background?.content, overflow: 'hidden' }}
         key={id}
         testID={id}
         onStartShouldSetResponder={dismissOnStartResponder}


### PR DESCRIPTION
Issue:
If the content of a story overflows the container it might overlap with the sidebar, preventing interactions with it.
<img width="933" alt="image" src="https://github.com/user-attachments/assets/1037fb81-8c1e-4656-8a1e-54e7bae6bad2">

## What I did
Set `overflow: hidden` to the content container.

<img width="936" alt="image" src="https://github.com/user-attachments/assets/dae68642-a1c5-4b25-8592-7313065b15e8">

For demonsteration purpose I changed the Button styles, but it's not part of the PR. @dannyhw Let me know if I should add an example story to demonstrate this.