### PR TITLE
fix: npx tsx confirmation prompt blocks

### DIFF
--- a/packages/react-native-theming/package.json
+++ b/packages/react-native-theming/package.json
@@ -21,8 +21,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "npx tsx ./scripts/gendtsdev.ts && tsup --watch",
-    "prepare": "tsup && npx tsx ./scripts/patchdts.ts"
+    "dev": "npx --yes tsx ./scripts/gendtsdev.ts && tsup --watch",
+    "prepare": "tsup && npx --yes tsx ./scripts/patchdts.ts"
   },
   "dependencies": {
     "polished": "^4.3.1"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -33,7 +33,7 @@
     "template/**/*"
   ],
   "scripts": {
-    "dev": "npx tsx buildscripts/gendtsdev.ts && tsup --watch",
+    "dev": "npx --yes tsx buildscripts/gendtsdev.ts && tsup --watch",
     "prepare": "rm -rf dist/ && tsup",
     "test": "jest",
     "test:ci": "jest"


### PR DESCRIPTION
```
node -v
v18.20.2
npm -v
10.5.0
```


Issue:

When using `yarn build` and not having `tsx` already in `npx` cache lerna does not expose the cli prompt of npx so the command just gets stuck at:

```
❯ yarn build
lerna notice cli v8.1.8

   ✔  @storybook/addon-ondevice-actions:prepare (2s)

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 Lerna (powered by Nx)   Running target prepare for 7 projects

   →  Executing 1/6 remaining tasks...

   ⠴  @storybook/react-native-theming:prepare

   ✔  1/1 succeeded [0 read from cache]
```

## What I did

I think there are 3 possible solutions

1. append --yes flag to npx commands to automatically confirm prompts
2. add `tsx` as devDependency
3. use `yarn dlx` instead (I think it does not require confirmation)

For the sake of simplicity I chose option 1

## How to test

Clear npx temporary cache to get prompt again

1. Run `rm -rf $(npm config get cache)/_npx`

2. Run `yarn build` again

3. If it does not get stuck verify that tsx is not already installed `npx tsx` should ask for prompt

```❯ npx tsx
Need to install the following packages:
tsx@4.19.1
Ok to proceed? (y)
```
