### PR TITLE
fix: add missing devDependency(ts-dedent)

### DIFF
--- a/packages/react-native-ui/package.json
+++ b/packages/react-native-ui/package.json
@@ -54,7 +54,8 @@
     "jest": "29.7.0",
     "react-test-renderer": "18.2.0",
     "tsup": "^7.2.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "ts-dedent": "^2.2.0"
   },
   "dependencies": {
     "@storybook/core": "^8.3.5",


### PR DESCRIPTION
Issue:

## What I did

add `ts-dedent` to devDependency

## How to test

`ts-dedent` is not in the devDependency list but it is required in `StoryHash.ts`

![storybookdemo](https://github.com/user-attachments/assets/c967536c-382c-45ff-8806-c16ae6eaab41)



Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example? No
- Does this need an update to the documentation? No


<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
