### PR TITLE
fix: add accessibilityLabel as story selector

### DIFF
--- a/packages/react-native/src/components/StoryView/StoryView.tsx
+++ b/packages/react-native/src/components/StoryView/StoryView.tsx
@@ -59,6 +59,7 @@ const StoryView = () => {
         style={containerStyle}
         key={id}
         testID={id}
+        accessibilityLabel={id}
         onStartShouldSetResponder={dismissOnStartResponder}
       >
         <ErrorBoundary onError={onError}>


### PR DESCRIPTION
Issue:
No issue

## What I did

Added `accessibilityLabel` property to `StoryView`.  

Allows Appium to select the story element in Android devices.

## How to test

1. Setup automated tests using WebdriverIO/Appium.  
1. Access the element using the [accessibility id](https://webdriver.io/docs/selectors/#accessibility-id)

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
