### PR TITLE
fix: android search icon color

### DIFF
--- a/packages/react-native-ui/src/Search.tsx
+++ b/packages/react-native-ui/src/Search.tsx
@@ -39,18 +39,17 @@ const options = {
   ],
 } as IFuseOptions<SearchItem>;
 
-const SearchIconWrapper = styled.View(({ theme }) => ({
+const SearchIconWrapper = styled.View({
   position: 'absolute',
   top: 0,
   left: 8,
   zIndex: 1,
   pointerEvents: 'none',
-  color: theme.textMutedColor,
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
   height: '100%',
-}));
+});
 
 const SearchField = styled.View({
   display: 'flex',

--- a/packages/react-native-ui/src/icon/SearchIcon.tsx
+++ b/packages/react-native-ui/src/icon/SearchIcon.tsx
@@ -1,19 +1,14 @@
-import * as React from 'react';
 import { Path, Svg, SvgProps } from 'react-native-svg';
+import { useTheme } from '@storybook/react-native-theming';
 
-export const SearchIcon = ({
-  color = 'currentColor',
-  width = 14,
-  height = 14,
-  ...props
-}: SvgProps) => {
+export const SearchIcon = ({ width = 14, height = 14, ...props }: SvgProps) => {
+  const theme = useTheme();
   return (
-    <Svg width={width} height={height} viewBox="0 0 14 14" fill="none" {...props}>
+    <Svg width={width} height={height} viewBox="0 0 14 14" fill={theme.color.dark} {...props}>
       <Path
         fillRule="evenodd"
         clipRule="evenodd"
         d="M9.544 10.206a5.5 5.5 0 11.662-.662.5.5 0 01.148.102l3 3a.5.5 0 01-.708.708l-3-3a.5.5 0 01-.102-.148zM10.5 6a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z"
-        fill={color}
       />
     </Svg>
   );


### PR DESCRIPTION
Issue: #687 

## What I did
Fix the SearchIcon on Android.
Tested on `Pixel_4a_API_34`

I used the same color as Storybook official [one](https://github.com/storybookjs/storybook/blob/14d1a37362289477eb9eb291c65e9b1f784aca5a/code/core/src/manager/components/sidebar/Search.tsx#L87)

## How to test
Run the Expo Sandbox

## Screenshots

| Before | After |
| - | - |
| ![Screenshot_1739640139](https://github.com/user-attachments/assets/0fa0d2c8-732d-463d-9d39-0e6134999769) | ![Screenshot_1739640112](https://github.com/user-attachments/assets/2b727f0c-d15b-46f1-94f7-775d54b6337f) |

