### PR TITLE
fix: use correct color for bar text

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "bootstrap": "node ./scripts/bootstrap.js",
+    "example": "yarn workspace expo-example storybook",
     "dev": "lerna run dev --stream --parallel",
     "dev:check-types": "tsc --noEmit",
     "github-release": "github-release-from-changelog",

--- a/packages/react-native-theming/src/web-theme.ts
+++ b/packages/react-native-theming/src/web-theme.ts
@@ -245,7 +245,7 @@ export const dark: ThemeVars = {
   textMutedColor: '#798186',
 
   // Toolbar default and active colors
-  barTextColor: '#798186',
+  barTextColor: color.mediumdark,
   barHoverColor: color.secondary,
   barSelectedColor: color.secondary,
   barBg: '#292C2E',

--- a/packages/react-native-ui/src/Layout.tsx
+++ b/packages/react-native-ui/src/Layout.tsx
@@ -146,9 +146,9 @@ export const Layout = ({
   const navButtonTextStyle = useStyle(
     () => ({
       flexShrink: 1,
-      color: theme.color.defaultText,
+      color: theme.barTextColor,
     }),
-    [theme.color.defaultText]
+    [theme.barTextColor]
   );
 
   const openMobileMenu = useCallback(() => {


### PR DESCRIPTION
Issue: part of #686 (I will do smaller and individual PR to avoid just shipping a bunch of changes at once)

## What I did
Fixed the "Bar Text" font and use the already available `theme.barTextColor` instead.

## How to test
Try with Expo sandboxes

## Screenshots

| Device + Theme | Before | After |
|-|-|-|
| iOS Light | ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-02-15 at 18 13 30](https://github.com/user-attachments/assets/0b88de97-45b7-44be-b110-29ef4ecd427f) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-02-15 at 18 10 09](https://github.com/user-attachments/assets/9ffc4680-e74a-4f21-98a6-2d292a656b8d) | 
| iOS Dark | ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-02-15 at 18 13 44](https://github.com/user-attachments/assets/b1607f26-a97d-4451-a4cf-b92e904e856b) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-02-15 at 18 10 00](https://github.com/user-attachments/assets/7a8d2eda-1e89-4d4c-8694-9f5f62565f05) | 
| Android Light | ![Screenshot_1739643158](https://github.com/user-attachments/assets/6353663f-b6ac-4132-9487-269692f0bce2) | ![Screenshot_1739643097](https://github.com/user-attachments/assets/924ee96f-707e-4094-804d-d31b62f7443a) | 
| Android Dark | ![Screenshot_1739643173](https://github.com/user-attachments/assets/f66873bd-96cc-4925-90ff-5843ef73a7ac) | ![Screenshot_1739643072](https://github.com/user-attachments/assets/37eff515-d290-4b2d-9399-0827f8969085) | 