### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Make sure you have `react-native-reanimated` in your project and the plugin setu
 
 ```js
 // babel.config.js
-plugins: ['react-native-reanimated/plugin'];
+plugins: ['react-native-reanimated/plugin'],
 ```
 
 ## Writing stories


### PR DESCRIPTION
Issue: #690 

## What I did
I replaced a semi-colon with a comma at the end of the line for the setup section.

### From the README.md file
Reanimated setup
Make sure you have react-native-reanimated in your project and the plugin setup in your babel config.
```js
// babel.config.js
plugins: ['react-native-reanimated/plugin']; // <---- This line
```
## How to test
No tests are needed.

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
