### PR TITLE
chore(deps): bump prettier from 2.4.1 to 3.5.3

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -54,7 +54,7 @@
     "commander": "^8.2.0",
     "dedent": "^1.5.1",
     "deepmerge": "^4.3.0",
-    "prettier": "^2.4.1",
+    "prettier": "^3.5.3",
     "react-native-url-polyfill": "^2.0.0",
     "setimmediate": "^1.0.5",
     "type-fest": "~2.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5825,7 +5825,7 @@ __metadata:
     jest: "npm:^29.7.0"
     jest-expo: "npm:~52.0.6"
     jotai: "npm:^2.6.2"
-    prettier: "npm:^2.4.1"
+    prettier: "npm:^3.5.3"
     react: "npm:18.3.1"
     react-native: "npm:0.76.7"
     react-native-url-polyfill: "npm:^2.0.0"
@@ -15553,12 +15553,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.4.1":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
+"prettier@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "prettier@npm:3.5.3"
   bin:
-    prettier: bin-prettier.js
-  checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
+    prettier: bin/prettier.cjs
+  checksum: 10/7050c08f674d9e49fbd9a4c008291d0715471f64e94cc5e4b01729affce221dfc6875c8de7e66b728c64abc9352eefb7eaae071b5f79d30081be207b53774b78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #709

## What I did
Bumped prettier version and ran yarn install to update lock file.

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
Tested changes by running build and test commands locally after change. 
