### PR TITLE
fix: prevent StoryView from intercepting Android TalkBack focus

### DIFF
--- a/packages/react-native/src/components/StoryView/StoryView.tsx
+++ b/packages/react-native/src/components/StoryView/StoryView.tsx
@@ -60,6 +60,7 @@ const StoryView = () => {
         key={id}
         testID={id}
         accessibilityLabel={id}
+        importantForAccessibility="no"
         onStartShouldSetResponder={dismissOnStartResponder}
       >
         <ErrorBoundary onError={onError}>


### PR DESCRIPTION
Issue: #743

## What I did

- Added `importantForAccessibility="no"` to the StoryView container component
- This prevents Android TalkBack from focusing on the StoryView wrapper, allowing proper focus on story components inside

## How to test

- Test on Android device/emulator with TalkBack enabled
- Create a story with an accessible component (one that has `accessibilityLabel`)
- Enable TalkBack and try to focus on the story component
- Verify that TalkBack can now properly focus on the story component instead of getting stuck on the StoryView container

- Does this need a new example in examples/expo-example? **No** - this is a bug fix that doesn't require new examples
- Does this need an update to the documentation? **No** - this is an internal accessibility fix that doesn't change the public API