### PR TITLE
chore: update pr template branch comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ If your answer is yes to any of these, please make sure to include it in your PR
 
 <!--
 
-Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.
+Everybody: Please submit all PRs to the `next` branch unless this is a backport for an older version. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.
 
 Maintainers: Please tag your pull request with at least one of the following:
 `["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`


### PR DESCRIPTION
## What I did

Current PR template mentions `next-6.0` branch and `5.3` version. This PR makes it a bit more generic.

## How to test

Open a PR, after this is merged as Github only considers the HEAD branch PR template.
