### PR TITLE
fix: StorybookConfig import and CLI command deprecation warnings

### DIFF
--- a/MANUAL_SETUP.md
+++ b/MANUAL_SETUP.md
@@ -13,7 +13,7 @@ npx create-expo-app --template expo-template-storybook AwesomeStorybook
 For react native cli you can use this [template](https://github.com/dannyhw/react-native-template-storybook)
 
 ```sh
-npx react-native init MyApp --template react-native-template-storybook
+npx @react-native-community/cli init MyApp --template react-native-template-storybook
 ```
 
 # Manual setup

--- a/MANUAL_SETUP.md
+++ b/MANUAL_SETUP.md
@@ -57,7 +57,7 @@ mkdir .rnstorybook && touch .rnstorybook/main.ts .rnstorybook/preview.tsx .rnsto
 ### .rnstorybook/main.ts
 
 ```ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ You should configure the path to your story files in the `main.ts` config file f
 
 ```ts
 // .rnstorybook/main.ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],
@@ -302,7 +302,7 @@ Install each one you want to use and add them to the `main.ts` addons list as fo
 
 ```ts
 // .rnstorybook/main.ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   // ... rest of config

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npx create-expo-app --template expo-template-storybook AwesomeStorybook
 For react native cli you can use this [template](https://github.com/dannyhw/react-native-template-storybook)
 
 ```sh
-npx react-native init MyApp --template react-native-template-storybook
+npx @react-native-community/cli init MyApp --template react-native-template-storybook
 ```
 
 ### Existing project

--- a/docs/docs/intro/addons/index.md
+++ b/docs/docs/intro/addons/index.md
@@ -16,7 +16,7 @@ The addons made available by us are the following. There are more addons availab
 To use these addons, add them to your `.storybook/main.ts`:
 
 ```ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   addons: [

--- a/docs/docs/intro/configuration/cli-configuration.md
+++ b/docs/docs/intro/configuration/cli-configuration.md
@@ -105,7 +105,7 @@ The CLI looks for these files in your config path:
 Defines stories location and addons:
 
 ```typescript
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],

--- a/docs/docs/intro/configuration/index.md
+++ b/docs/docs/intro/configuration/index.md
@@ -20,7 +20,7 @@ The storybook configuration consists of several key files:
 The `main.ts` file is your primary configuration entry point, located in the `.storybook` directory.
 
 ```typescript
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: [

--- a/docs/docs/intro/getting-started/index.md
+++ b/docs/docs/intro/getting-started/index.md
@@ -123,7 +123,7 @@ npx create-expo-app --template expo-template-storybook AwesomeStorybook
 For React Native cli you can use this template
 
 ```bash
-npx react-native init MyApp --template react-native-template-storybook
+npx @react-native-community/cli init MyApp --template react-native-template-storybook
 ```
 
 ## Starter projects

--- a/docs/docs/intro/getting-started/manual-setup.md
+++ b/docs/docs/intro/getting-started/manual-setup.md
@@ -36,7 +36,7 @@ touch .rnstorybook/main.ts .rnstorybook/preview.tsx .rnstorybook/index.tsx
 In `main.ts`, configure the location of your stories:
 
 ```ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],

--- a/examples/expo-example/.rnstorybook/main.ts
+++ b/examples/expo-example/.rnstorybook/main.ts
@@ -1,4 +1,4 @@
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: [

--- a/packages/ondevice-actions/README.md
+++ b/packages/ondevice-actions/README.md
@@ -13,7 +13,7 @@ yarn add -D @storybook/addon-ondevice-actions
 Then, add following content to `.rnstorybook/main.ts`:
 
 ```ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   addons: ['@storybook/addon-ondevice-actions'],

--- a/packages/ondevice-backgrounds/README.md
+++ b/packages/ondevice-backgrounds/README.md
@@ -13,7 +13,7 @@ yarn add -D @storybook/addon-ondevice-backgrounds
 Then, add following content to `.rnstorybook/main.ts`:
 
 ```ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   addons: ['@storybook/addon-ondevice-backgrounds'],

--- a/packages/ondevice-controls/README.md
+++ b/packages/ondevice-controls/README.md
@@ -15,7 +15,7 @@ yarn add -D @storybook/addon-ondevice-controls @react-native-community/datetimep
 Then, add following content to `.rnstorybook/main.ts`:
 
 ```ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   addons: ['@storybook/addon-ondevice-controls'],

--- a/packages/ondevice-notes/README.md
+++ b/packages/ondevice-notes/README.md
@@ -13,7 +13,7 @@ yarn add -D @storybook/addon-ondevice-notes
 Then, add following content to `.rnstorybook/main.ts`:
 
 ```ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   addons: ['@storybook/addon-ondevice-notes'],

--- a/packages/react-native/readme.md
+++ b/packages/react-native/readme.md
@@ -40,7 +40,7 @@ npx create-expo-app --template expo-template-storybook AwesomeStorybook
 For react native cli you can use this [template](https://github.com/dannyhw/react-native-template-storybook)
 
 ```sh
-npx react-native init MyApp --template react-native-template-storybook
+npx @react-native-community/cli init MyApp --template react-native-template-storybook
 ```
 
 ### Existing project

--- a/packages/react-native/readme.md
+++ b/packages/react-native/readme.md
@@ -176,7 +176,7 @@ You should configure the path to your story files in the `main.ts` config file f
 
 ```ts
 // .rnstorybook/main.ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],
@@ -265,7 +265,7 @@ Install each one you want to use and add them to the `main.ts` addons list as fo
 
 ```ts
 // .rnstorybook/main.ts
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   // ... rest of config

--- a/packages/react-native/template/cli/main.ts
+++ b/packages/react-native/template/cli/main.ts
@@ -1,4 +1,4 @@
-import { StorybookConfig } from '@storybook/react-native';
+import type { StorybookConfig } from '@storybook/react-native';
 
 const main: StorybookConfig = {
   stories: ['./stories/**/*.stories.?(ts|tsx|js|jsx)'],


### PR DESCRIPTION
This PR fixes two issues that were causing build errors and deprecation warnings.

## Issue 1: `StorybookConfig` Import Error
StorybookConfig import was causing build errors with the error message: 

<img width="782" alt="The requested module '@storybook/react-native' does not provide an export named 'StorybookConfig'" src="https://github.com/user-attachments/assets/809228dd-4309-4276-9acf-129a706dbbf2" />

_SyntaxError: The requested module `@storybook/react-native` does not provide an export named `StorybookConfig`_

### What I did
- Changed to type-only import to fix the compilation error
  from `import { StorybookConfig }` to `import type { StorybookConfig }`
- Updated documentation to use current code snippets

### How to Test
1. **Install dependencies and build the project from the root directory:**
```
yarn install
yarn build
```
2. **Navigate to the example app and run it on WEB:**
```
cd examples/expo-example
yarn web
```
should work without TypeScript errors

- **Does this need a new example in examples/expo-example?**
No - the existing example now works correctly with the import fix.

- **Does this need an update to the documentation?**
Yes - README files have been updated to show the correct import pattern.

## Issue 2: Deprecated CLI Command Warnings
Deprecated `npx react-native init` command was causing warnings: 

_"🚨️ The `init` command is deprecated. Switch to `npx @react-native-community/cli init` for the identical behavior."_

### What I did
- Updated to use `npx @react-native-community/cli init`
- Updated documentation to use current CLI syntax

### How to test
1. **Test the updated CLI command:**
   ```bash
   # Try the new command format
   npx @react-native-community/cli init MyApp --template react-native-template-storybook
   ```
   Should work without deprecation warnings.

2. **Check that CLI commands in documentation use current syntax**

- **Does this need a new example in examples/expo-example?**
No - this only affects documentation, not the example code.

- **Does this need an update to the documentation?**
Yes - documentation has been updated to use current CLI commands instead of deprecated ones.

