### PR TITLE
fix: for lite ui remove references to safearea and use safearea context instead as a direct dependency

### DIFF
--- a/examples/expo-example/.rnstorybook/index.tsx
+++ b/examples/expo-example/.rnstorybook/index.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-// import { LiteUI } from '@storybook/react-native-ui-lite';
-import { SafeAreaView, StatusBar, View } from 'react-native';
-
+import { LiteUI } from '@storybook/react-native-ui-lite';
+// import { StatusBar, View } from 'react-native';
+// import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
 import { view } from './storybook.requires';
 
 const isScreenshotTesting = process.env.EXPO_PUBLIC_SCREENSHOT_TESTING === 'true';
@@ -16,19 +16,26 @@ const StorybookUIRoot = view.getStorybookUI({
   host: 'localhost',
   port: 7007,
 
-  // CustomUIComponent: LiteUI,
-  CustomUIComponent: isScreenshotTesting
-    ? ({ children, story }) => {
-        return (
-          <SafeAreaView style={{ flex: 1 }}>
-            <StatusBar hidden />
-            <View style={{ flex: 1 }} accessibilityLabel={story?.id} testID={story?.id} accessible>
-              {children}
-            </View>
-          </SafeAreaView>
-        );
-      }
-    : undefined,
+  CustomUIComponent: LiteUI,
+  // CustomUIComponent: isScreenshotTesting
+  //   ? ({ children, story }) => {
+  //       return (
+  //         <SafeAreaProvider>
+  //           <SafeAreaView style={{ flex: 1 }}>
+  //             <StatusBar hidden />
+  //             <View
+  //               style={{ flex: 1 }}
+  //               accessibilityLabel={story?.id}
+  //               testID={story?.id}
+  //               accessible
+  //             >
+  //               {children}
+  //             </View>
+  //           </SafeAreaView>
+  //         </SafeAreaProvider>
+  //       );
+  //     }
+  //   : undefined,
 });
 
 export default StorybookUIRoot;

--- a/packages/react-native-ui-lite/src/Layout.tsx
+++ b/packages/react-native-ui-lite/src/Layout.tsx
@@ -11,15 +11,7 @@ import {
   useStyle,
 } from '@storybook/react-native-ui-common';
 import { ReactElement, ReactNode, useCallback, useRef, useState } from 'react';
-import {
-  Platform,
-  SafeAreaView,
-  ScrollView,
-  Text,
-  TouchableOpacity,
-  View,
-  ViewStyle,
-} from 'react-native';
+import { Platform, ScrollView, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
 import { SET_CURRENT_STORY } from 'storybook/internal/core-events';
 import { addons } from 'storybook/manager-api';
 import { type API_IndexHash } from 'storybook/internal/types';
@@ -35,6 +27,7 @@ import {
   FullscreenIcon,
   MenuIcon,
 } from './icon/iconDataUris';
+import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const desktopLogoContainer = {
   flexDirection: 'row',
@@ -65,9 +58,8 @@ const mobileMenuDrawerContentStyle = {
 } satisfies ViewStyle;
 
 export const LiteUI: SBUI = ({ storage, theme, storyHash, story, children }): ReactElement => (
-  <>
+  <SafeAreaProvider style={{ flex: 1 }}>
     <ThemeProvider theme={theme}>
-      {/* @ts-ignore something weird with story type */}
       <StorageProvider storage={storage}>
         <LayoutProvider>
           <Layout storyHash={storyHash} story={story}>
@@ -76,7 +68,7 @@ export const LiteUI: SBUI = ({ storage, theme, storyHash, story, children }): Re
         </LayoutProvider>
       </StorageProvider>
     </ThemeProvider>
-  </>
+  </SafeAreaProvider>
 );
 
 export const Layout = ({
@@ -91,6 +83,8 @@ export const Layout = ({
   const theme = useTheme();
 
   const { isDesktop } = useLayout();
+
+  const insets = useSafeAreaInsets();
 
   const [desktopSidebarOpen, setDesktopSidebarOpen] = useStoreBooleanState(
     'desktopSidebarState',
@@ -137,9 +131,16 @@ export const Layout = ({
     return {
       flex: 1,
       backgroundColor: theme.background.content,
-      paddingVertical: Platform.OS === 'android' ? 32 : 0,
+      paddingTop: story?.parameters?.noSafeArea ? 0 : insets.top,
     };
   }, [theme.background.content, story?.parameters?.noSafeArea, isDesktop]);
+
+  const navContainerStyle = useStyle(
+    () => ({
+      paddingBottom: insets.bottom,
+    }),
+    [insets.bottom]
+  );
 
   const fullScreenButtonStyle = useStyle(
     () => ({
@@ -173,7 +174,7 @@ export const Layout = ({
   }, []);
 
   return (
-    <SafeAreaView style={containerStyle}>
+    <View style={containerStyle}>
       {isDesktop ? (
         <View style={desktopSidebarStyle}>
           {desktopSidebarOpen ? (
@@ -233,7 +234,7 @@ export const Layout = ({
       </View>
 
       {!uiHidden && !isDesktop ? (
-        <Container>
+        <Container style={navContainerStyle}>
           <Nav>
             <Button
               testID="mobile-menu-button"
@@ -278,7 +279,7 @@ export const Layout = ({
       )}
 
       {isDesktop ? null : <MobileAddonsPanel ref={addonPanelRef} storyId={story?.id} />}
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/packages/react-native-ui-lite/src/MobileAddonsPanel.tsx
+++ b/packages/react-native-ui-lite/src/MobileAddonsPanel.tsx
@@ -1,12 +1,11 @@
 import { styled, useTheme } from '@storybook/react-native-theming';
-import { IconButton } from '@storybook/react-native-ui-common';
+import { IconButton, useStyle } from '@storybook/react-native-ui-common';
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import {
   Animated,
   Easing,
   Keyboard,
   Platform,
-  SafeAreaView,
   ScrollView,
   StyleProp,
   Text,
@@ -18,6 +17,7 @@ import { addons } from 'storybook/manager-api';
 import { Addon_TypesEnum } from 'storybook/internal/types';
 import { CloseIcon } from './icon/iconDataUris';
 import useAnimatedValue from './useAnimatedValue';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export interface MobileAddonsPanelRef {
   setAddonsPanelOpen: (isOpen: boolean) => void;
@@ -110,7 +110,7 @@ export const MobileAddonsPanel = forwardRef<MobileAddonsPanelRef, { storyId?: st
           transform: [{ translateY: positionBottomAnimation }],
         }}
       >
-        <SafeAreaView
+        <View
           style={{
             justifyContent: 'flex-end',
           }}
@@ -132,7 +132,7 @@ export const MobileAddonsPanel = forwardRef<MobileAddonsPanelRef, { storyId?: st
               storyId={storyId}
             />
           </View>
-        </SafeAreaView>
+        </View>
       </Animated.View>
     );
   }
@@ -170,14 +170,11 @@ const centeredStyle = {
   justifyContent: 'center',
 } satisfies StyleProp<ViewStyle>;
 
-const scrollContentContainerStyle = {
-  paddingBottom: 16,
-} satisfies StyleProp<ViewStyle>;
 const hitSlop = { top: 10, right: 10, bottom: 10, left: 10 };
 
 export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId?: string }) => {
   const panels = addons.getElements(Addon_TypesEnum.PANEL);
-
+  const insets = useSafeAreaInsets();
   const [addonSelected, setAddonSelected] = useState(Object.keys(panels)[0]);
 
   const panel = useMemo(() => {
@@ -199,6 +196,13 @@ export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId
 
     return panels[addonSelected].render({ active: true });
   }, [addonSelected, panels, storyId]);
+
+  const scrollContentContainerStyle = useStyle(
+    () => ({
+      paddingBottom: insets.bottom + 16,
+    }),
+    [insets]
+  );
 
   return (
     <View style={addonsTabsContainerStyle}>

--- a/packages/react-native-ui-lite/src/MobileMenuDrawer.tsx
+++ b/packages/react-native-ui-lite/src/MobileMenuDrawer.tsx
@@ -8,11 +8,9 @@ import {
   PanResponder,
   PanResponderInstance,
   Pressable,
-  SafeAreaView,
   ScrollView,
   View,
 } from 'react-native';
-
 import { useSelectedNode } from './SelectedNodeProvider';
 import useAnimatedValue from './useAnimatedValue';
 
@@ -98,51 +96,49 @@ export const MobileMenuDrawer = memo(
         onRequestClose={() => setMobileMenuOpen(false)}
       >
         <KeyboardAvoidingView behavior="height" style={{ flex: 1 }}>
-          <SafeAreaView style={{ justifyContent: 'flex-end', flex: 1 }}>
-            <View style={{ flex: 1 }}>
-              <Pressable style={{ flex: 1 }} onPress={() => setMobileMenuOpen(false)}></Pressable>
+          <View style={{ flex: 1 }}>
+            <Pressable style={{ flex: 1 }} onPress={() => setMobileMenuOpen(false)}></Pressable>
+          </View>
+
+          <Animated.View
+            style={[
+              {
+                height: '65%',
+                borderTopColor: theme.appBorderColor,
+                borderTopWidth: 1,
+                borderStyle: 'solid',
+                backgroundColor: theme.background.content,
+                elevation: 8,
+              },
+              { transform: [{ translateY: dragY }] },
+            ]}
+          >
+            {/* Drag handle */}
+            <View
+              {...panResponder.panHandlers}
+              style={{
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.background.content,
+              }}
+            >
+              <View style={handleStyle} />
             </View>
 
-            <Animated.View
-              style={[
-                {
-                  height: '65%',
-                  borderTopColor: theme.appBorderColor,
-                  borderTopWidth: 1,
-                  borderStyle: 'solid',
-                  backgroundColor: theme.background.content,
-                  elevation: 8,
-                },
-                { transform: [{ translateY: dragY }] },
-              ]}
+            <ScrollView
+              ref={scrollRef}
+              keyboardShouldPersistTaps="handled"
+              style={{
+                flex: 1,
+                paddingBottom: 150,
+                alignSelf: 'flex-end',
+                width: '100%',
+                backgroundColor: theme.background.content,
+              }}
             >
-              {/* Drag handle */}
-              <View
-                {...panResponder.panHandlers}
-                style={{
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor: theme.background.content,
-                }}
-              >
-                <View style={handleStyle} />
-              </View>
-
-              <ScrollView
-                ref={scrollRef}
-                keyboardShouldPersistTaps="handled"
-                style={{
-                  flex: 1,
-                  paddingBottom: 150,
-                  alignSelf: 'flex-end',
-                  width: '100%',
-                  backgroundColor: theme.background.content,
-                }}
-              >
-                {children}
-              </ScrollView>
-            </Animated.View>
-          </SafeAreaView>
+              {children}
+            </ScrollView>
+          </Animated.View>
         </KeyboardAvoidingView>
       </Modal>
     );

--- a/packages/react-native-ui-lite/src/Search.tsx
+++ b/packages/react-native-ui-lite/src/Search.tsx
@@ -2,7 +2,7 @@ import { styled } from '@storybook/react-native-theming';
 import type { IFuseOptions } from 'fuse.js';
 import Fuse from 'fuse.js';
 import React, { useCallback, useDeferredValue, useRef, useState } from 'react';
-import { TextInput, View } from 'react-native';
+import { Platform, TextInput, View } from 'react-native';
 import { useSelectedNode } from './SelectedNodeProvider';
 import {
   type CombinedDataset,
@@ -54,7 +54,8 @@ const SearchField = styled.View({
 });
 
 const Input = styled(TextInput)(({ theme }) => ({
-  height: 32,
+  height: Platform.OS === 'android' ? 'auto' : 32,
+  minHeight: 32,
   paddingLeft: 28,
   paddingRight: 28,
   borderWidth: 1,
@@ -207,7 +208,12 @@ export const Search = React.memo<{
           <SearchIcon />
         </SearchIconWrapper>
 
-        <Input ref={inputRef} onChangeText={setInputValue} onFocus={() => setIsOpen(true)} />
+        <Input
+          ref={inputRef}
+          onChangeText={setInputValue}
+          onFocus={() => setIsOpen(true)}
+          returnKeyType="search"
+        />
 
         {isOpen && (
           <ClearIcon


### PR DESCRIPTION
Issue:

## What I did

Since we no longer can use safearea view we will need the safe area context package as a dependency, this makes that change and also fixes some minor issues with the lite ui

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
