### PR TITLE
chore: update rntl to latest beta

### DIFF
--- a/examples/expo-example/components/ActionExample/Actions.test.tsx
+++ b/examples/expo-example/components/ActionExample/Actions.test.tsx
@@ -9,7 +9,7 @@ test('action story renders and onpress works', async () => {
 
   const onPress = jest.fn();
 
-  render(<Basic onPress={onPress} />);
+  await render(<Basic onPress={onPress} />);
 
   const user = userEvent.setup({});
 

--- a/examples/expo-example/components/BackgroundExample/BackgroundCsf.test.tsx
+++ b/examples/expo-example/components/BackgroundExample/BackgroundCsf.test.tsx
@@ -5,8 +5,8 @@ import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
 
 const { Basic } = composeStories(Backgrounds, { decorators: [withBackgrounds] });
 
-test('Background colour is hotpink', () => {
-  render(<Basic />);
+test('Background colour is hotpink', async () => {
+  await render(<Basic />);
 
   expect(screen.getByTestId('addon-backgrounds-container')).toHaveStyle({
     backgroundColor: 'hotpink',

--- a/examples/expo-example/components/ControlExamples/Array/Array.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Array/Array.test.tsx
@@ -5,8 +5,8 @@ import * as ArrayStories from './Array.stories';
 // @ts-expect-error
 const { Basic } = composeStories(ArrayStories);
 
-test('array story renders', () => {
-  render(<Basic />);
+test('array story renders', async () => {
+  await render(<Basic />);
 
   expect(screen.getByTestId('array-story-container')).toHaveTextContent(/abc/);
 });

--- a/examples/expo-example/components/ControlExamples/Boolean/Boolean.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Boolean/Boolean.test.tsx
@@ -4,14 +4,14 @@ import * as BooleanStories from './Boolean.stories';
 
 const { Basic, On } = composeStories(BooleanStories);
 
-test('boolean story renders', () => {
-  render(<Basic />);
+test('boolean story renders', async () => {
+  await render(<Basic />);
 
   screen.getByText('off');
 });
 
-test('boolean story renders on', () => {
-  render(<On />);
+test('boolean story renders on', async () => {
+  await render(<On />);
 
   screen.getByText('on');
 });

--- a/examples/expo-example/components/ControlExamples/Color/Color.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Color/Color.test.tsx
@@ -4,8 +4,8 @@ import * as Color from './Color.stories';
 
 const { ColorExample } = composeStories(Color);
 
-test('color story renders', () => {
-  render(<ColorExample />);
+test('color story renders', async () => {
+  await render(<ColorExample />);
 
   expect(screen.getByTestId('color-story-container')).toHaveStyle({ backgroundColor: '#a819b9' });
 });

--- a/examples/expo-example/components/ControlExamples/Date/Date.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Date/Date.test.tsx
@@ -4,8 +4,8 @@ import * as DateStories from './Date.stories';
 
 const { Basic } = composeStories(DateStories);
 
-test('date story renders', () => {
-  render(<Basic />);
+test('date story renders', async () => {
+  await render(<Basic />);
 
   const date = new Date(1983, 1, 25);
 

--- a/examples/expo-example/components/ControlExamples/Number/Number.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Number/Number.test.tsx
@@ -5,13 +5,13 @@ import * as NumberStories from './Number.stories';
 const { Basic, Range } = composeStories(NumberStories);
 
 test('basic story renders', async () => {
-  render(<Basic />);
+  await render(<Basic />);
 
   await screen.findByText(/5 x 3 = 15/);
 });
 
 test('range story renders', async () => {
-  render(<Range />);
+  await render(<Range />);
 
   await screen.findByText(/6 x 7 = 42/);
 });

--- a/examples/expo-example/components/ControlExamples/Object/Object.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Object/Object.test.tsx
@@ -4,8 +4,8 @@ import * as ObjectStory from './Object.stories';
 
 const { Basic } = composeStories(ObjectStory);
 
-test('object story renders', () => {
-  render(<Basic />);
+test('object story renders', async () => {
+  await render(<Basic />);
 
   screen.getByText('title: Blade Runner');
   screen.getByText('genre: Sci Fi');

--- a/examples/expo-example/components/ControlExamples/Radio/Radio.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Radio/Radio.test.tsx
@@ -4,8 +4,8 @@ import * as RadioStories from './Radio.stories';
 
 const { Basic } = composeStories(RadioStories);
 
-test('radio story renders', () => {
-  render(<Basic />);
+test('radio story renders', async () => {
+  await render(<Basic />);
 
   screen.getByText('104.8MHz');
 });

--- a/examples/expo-example/components/ControlExamples/Select/Select.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Select/Select.test.tsx
@@ -4,21 +4,21 @@ import * as SelectStories from './Select.stories';
 
 const { Basic, WithLabels, WithMapping } = composeStories(SelectStories);
 
-test('select story renders', () => {
-  render(<Basic />);
+test('select story renders', async () => {
+  await render(<Basic />);
 
   screen.getByText('Selected: ⬅️');
 });
 
-test('select with labels story renders', () => {
-  render(<WithLabels />);
+test('select with labels story renders', async () => {
+  await render(<WithLabels />);
 
   screen.getByText('Selected: ⬆');
 });
 
 // TODO: Fix this test
 test.skip('select with mapping story renders', async () => {
-  render(<WithMapping />);
+  await render(<WithMapping />);
 
   await screen.findByText('Selected: ➡️');
 });

--- a/examples/expo-example/components/ControlExamples/Text/Text.test.tsx
+++ b/examples/expo-example/components/ControlExamples/Text/Text.test.tsx
@@ -4,8 +4,8 @@ import * as TextStories from './Text.stories';
 
 const { Basic } = composeStories(TextStories);
 
-test('text story renders', () => {
-  render(<Basic />);
+test('text story renders', async () => {
+  await render(<Basic />);
 
   screen.getByText('Hello world!');
 });

--- a/examples/expo-example/components/InputExample/TextInput.test.tsx
+++ b/examples/expo-example/components/InputExample/TextInput.test.tsx
@@ -4,8 +4,8 @@ import * as InputStories from './TextInput.stories';
 
 const { Basic } = composeStories(InputStories);
 
-test('text input story renders', () => {
-  render(<Basic />);
+test('text input story renders', async () => {
+  await render(<Basic />);
 
   screen.getByPlaceholderText('Type something');
 });

--- a/examples/expo-example/package.json
+++ b/examples/expo-example/package.json
@@ -58,14 +58,14 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
-    "@testing-library/react-native": "14.0.0-alpha.1",
+    "@testing-library/react-native": "14.0.0-beta.0",
     "@types/react": "~19.1.10",
     "@types/ws": "^8.18.1",
     "babel-plugin-react-docgen-typescript": "^1.5.1",
     "jest": "^29.7.0",
     "jest-expo": "~54.0.16",
+    "test-renderer": "^0.14.0",
     "typescript": "~5.9.3",
-    "universal-test-renderer": "^0.6.0",
     "vite": "^7.1.12"
   }
 }

--- a/packages/react-native-ui-common/package.json
+++ b/packages/react-native-ui-common/package.json
@@ -29,30 +29,10 @@
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "prepare": "tsup",
-    "test": "jest --passWithNoTests",
-    "test:ci": "jest"
-  },
-  "jest": {
-    "modulePathIgnorePatterns": [
-      "dist/"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "preset": "react-native"
+    "prepare": "tsup"
   },
   "devDependencies": {
-    "@types/jest": "^29.4.3",
     "@types/react": "~19.1.10",
-    "babel-jest": "^29.7.0",
-    "jest": "^29.7.0",
-    "react-test-renderer": "^19.1.0",
     "tsup": "^8.5.0",
     "typescript": "~5.9.3"
   },

--- a/packages/react-native-ui-lite/package.json
+++ b/packages/react-native-ui-lite/package.json
@@ -29,30 +29,10 @@
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "prepare": "tsup",
-    "test": "jest --passWithNoTests",
-    "test:ci": "jest"
-  },
-  "jest": {
-    "modulePathIgnorePatterns": [
-      "dist/"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "preset": "react-native"
+    "prepare": "tsup"
   },
   "devDependencies": {
-    "@types/jest": "^29.4.3",
     "@types/react": "~19.1.10",
-    "babel-jest": "^29.7.0",
-    "jest": "^29.7.0",
-    "react-test-renderer": "^19.1.0",
     "ts-dedent": "^2.2.0",
     "tsup": "^8.5.0",
     "typescript": "~5.9.3"

--- a/packages/react-native-ui/package.json
+++ b/packages/react-native-ui/package.json
@@ -29,30 +29,10 @@
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "prepare": "tsup",
-    "test": "jest --passWithNoTests",
-    "test:ci": "jest"
-  },
-  "jest": {
-    "modulePathIgnorePatterns": [
-      "dist/"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "preset": "react-native"
+    "prepare": "tsup"
   },
   "devDependencies": {
-    "@types/jest": "^29.4.3",
     "@types/react": "~19.1.10",
-    "babel-jest": "^29.7.0",
-    "jest": "^29.7.0",
-    "react-test-renderer": "^19.1.0",
     "tsup": "^8.5.0",
     "typescript": "~5.9.3"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -73,9 +73,9 @@
     "react": "19.1.0",
     "react-native": "0.81.5",
     "storybook": "10.2.0-beta.1",
+    "test-renderer": "^0.14.0",
     "tsup": "^8.5.0",
-    "typescript": "~5.9.3",
-    "universal-test-renderer": "^0.6.0"
+    "typescript": "~5.9.3"
   },
   "peerDependencies": {
     "@gorhom/bottom-sheet": ">=4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8281,14 +8281,10 @@ __metadata:
   dependencies:
     "@storybook/react": "npm:10.2.0-beta.1"
     "@storybook/react-native-theming": "npm:^10.2.0-beta.1"
-    "@types/jest": "npm:^29.4.3"
     "@types/react": "npm:~19.1.10"
-    babel-jest: "npm:^29.7.0"
     es-toolkit: "npm:^1.41.0"
     fuse.js: "npm:^7.1.0"
-    jest: "npm:^29.7.0"
     memoizerific: "npm:^1.11.3"
-    react-test-renderer: "npm:^19.1.0"
     ts-dedent: "npm:^2.2.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:~5.9.3"
@@ -8307,14 +8303,10 @@ __metadata:
     "@storybook/react": "npm:10.2.0-beta.1"
     "@storybook/react-native-theming": "npm:^10.2.0-beta.1"
     "@storybook/react-native-ui-common": "npm:^10.2.0-beta.1"
-    "@types/jest": "npm:^29.4.3"
     "@types/react": "npm:~19.1.10"
-    babel-jest: "npm:^29.7.0"
     fuse.js: "npm:^7.1.0"
-    jest: "npm:^29.7.0"
     polished: "npm:^4.3.1"
     react-native-safe-area-context: "npm:^5"
-    react-test-renderer: "npm:^19.1.0"
     ts-dedent: "npm:^2.2.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:~5.9.3"
@@ -8333,13 +8325,9 @@ __metadata:
     "@storybook/react": "npm:10.2.0-beta.1"
     "@storybook/react-native-theming": "npm:^10.2.0-beta.1"
     "@storybook/react-native-ui-common": "npm:^10.2.0-beta.1"
-    "@types/jest": "npm:^29.4.3"
     "@types/react": "npm:~19.1.10"
-    babel-jest: "npm:^29.7.0"
     fuse.js: "npm:^7.1.0"
-    jest: "npm:^29.7.0"
     polished: "npm:^4.3.1"
-    react-test-renderer: "npm:^19.1.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:~5.9.3"
   peerDependencies:
@@ -8399,9 +8387,9 @@ __metadata:
     react-native-url-polyfill: "npm:^3.0.0"
     setimmediate: "npm:^1.0.5"
     storybook: "npm:10.2.0-beta.1"
+    test-renderer: "npm:^0.14.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:~5.9.3"
-    universal-test-renderer: "npm:^0.6.0"
     ws: "npm:^8.18.3"
   peerDependencies:
     "@gorhom/bottom-sheet": ">=4"
@@ -8905,23 +8893,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react-native@npm:14.0.0-alpha.1":
-  version: 14.0.0-alpha.1
-  resolution: "@testing-library/react-native@npm:14.0.0-alpha.1"
+"@testing-library/react-native@npm:14.0.0-beta.0":
+  version: 14.0.0-beta.0
+  resolution: "@testing-library/react-native@npm:14.0.0-beta.0"
   dependencies:
-    chalk: "npm:^4.1.2"
-    jest-matcher-utils: "npm:^29.7.0"
-    pretty-format: "npm:^29.7.0"
+    jest-matcher-utils: "npm:^30.2.0"
+    picocolors: "npm:^1.1.1"
+    pretty-format: "npm:^30.2.0"
     redent: "npm:^3.0.0"
   peerDependencies:
     jest: ">=29.0.0"
     react: ">=19.0.0"
-    react-native: ">=0.77"
-    universal-test-renderer: 0.6.0
+    react-native: ">=0.78"
+    test-renderer: ^0.14.0
   peerDependenciesMeta:
     jest:
       optional: true
-  checksum: 10/7a6a148610d7d5e58b2b34908e9531e0c650b36c6739c46647a4587713275fcc7e3295713f6f0ca325750536b7abf41597b2fd1b746ed95d4832ea2f7bc4ee41
+  checksum: 10/8bd7b235ec1684752511086aa4ce488b4672f228796fc9fc64e7d5bf1600608e3767dc5d1eca7bb48adc2e8dbad2ae351b3924e758a1d45715951929152f86aa
   languageName: node
   linkType: hard
 
@@ -9430,6 +9418,15 @@ __metadata:
   version: 1.2.7
   resolution: "@types/range-parser@npm:1.2.7"
   checksum: 10/95640233b689dfbd85b8c6ee268812a732cf36d5affead89e806fe30da9a430767af8ef2cd661024fd97e19d61f3dec75af2df5e80ec3bea000019ab7028629a
+  languageName: node
+  linkType: hard
+
+"@types/react-reconciler@npm:~0.31.0":
+  version: 0.31.0
+  resolution: "@types/react-reconciler@npm:0.31.0"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/28930cc1627d46ab90fe2e9cf54cab7d28f60387ab5833d13841cbf88bdbba202c49e282bd94c579f1a6f6a4493015562088df90cb087cb9a8f837fbb5f9f212
   languageName: node
   linkType: hard
 
@@ -15089,7 +15086,7 @@ __metadata:
     "@storybook/react-native": "npm:^10.2.0-beta.1"
     "@storybook/react-native-ui-lite": "npm:^10.2.0-beta.1"
     "@storybook/react-native-web-vite": "npm:10.2.0-beta.1"
-    "@testing-library/react-native": "npm:14.0.0-alpha.1"
+    "@testing-library/react-native": "npm:14.0.0-beta.0"
     "@types/react": "npm:~19.1.10"
     "@types/ws": "npm:^8.18.1"
     babel-plugin-react-compiler: "npm:^1.0.0"
@@ -15110,8 +15107,8 @@ __metadata:
     react-native-worklets: "npm:0.5.1"
     storybook: "npm:10.2.0-beta.1"
     storybook-addon-deep-controls: "npm:^0.9.5"
+    test-renderer: "npm:^0.14.0"
     typescript: "npm:~5.9.3"
-    universal-test-renderer: "npm:^0.6.0"
     vite: "npm:^7.1.12"
     ws: "npm:^8.18.3"
   languageName: unknown
@@ -18161,7 +18158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:>=30.0.0 < 31, jest-diff@npm:^30.0.2":
+"jest-diff@npm:30.2.0, jest-diff@npm:>=30.0.0 < 31, jest-diff@npm:^30.0.2":
   version: 30.2.0
   resolution: "jest-diff@npm:30.2.0"
   dependencies:
@@ -18322,6 +18319,18 @@ __metadata:
     jest-get-type: "npm:^29.6.3"
     pretty-format: "npm:^29.7.0"
   checksum: 10/981904a494299cf1e3baed352f8a3bd8b50a8c13a662c509b6a53c31461f94ea3bfeffa9d5efcfeb248e384e318c87de7e3baa6af0f79674e987482aa189af40
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^30.2.0":
+  version: 30.2.0
+  resolution: "jest-matcher-utils@npm:30.2.0"
+  dependencies:
+    "@jest/get-type": "npm:30.1.0"
+    chalk: "npm:^4.1.2"
+    jest-diff: "npm:30.2.0"
+    pretty-format: "npm:30.2.0"
+  checksum: 10/f3f1ecf68ca63c9d1d80a175637a8fc655edfd1ee83220f6e3f6bd464ecbe2f93148fdd440a5a5e5a2b0b2cc8ee84ddc3dcef58a6dbc66821c792f48d260c6d4
   languageName: node
   linkType: hard
 
@@ -23879,7 +23888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:30.2.0":
+"pretty-format@npm:30.2.0, pretty-format@npm:^30.2.0":
   version: 30.2.0
   resolution: "pretty-format@npm:30.2.0"
   dependencies:
@@ -24665,7 +24674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-test-renderer@npm:19.1.0, react-test-renderer@npm:^19.1.0":
+"react-test-renderer@npm:19.1.0":
   version: 19.1.0
   resolution: "react-test-renderer@npm:19.1.0"
   dependencies:
@@ -27306,6 +27315,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"test-renderer@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "test-renderer@npm:0.14.0"
+  dependencies:
+    "@types/react-reconciler": "npm:~0.31.0"
+    react-reconciler: "npm:~0.31.0"
+  peerDependencies:
+    react: ^19.0.0
+  checksum: 10/46a62d42c32dc73da8c948ec6caec1594bd6c1c50c9d6a7dd790286957d6855774ecd82212ccca366bc2a76e83d9d6b3e03e0244d2a18cb6b8c2a409aff4e1d3
+  languageName: node
+  linkType: hard
+
 "text-extensions@npm:^1.0.0":
   version: 1.9.0
   resolution: "text-extensions@npm:1.9.0"
@@ -28142,17 +28163,6 @@ __metadata:
     unist-util-is: "npm:^6.0.0"
     unist-util-visit-parents: "npm:^6.0.0"
   checksum: 10/f2bbde23641e9ade7640358c06ddeec0f38342322eb8e7819d9ee380b0f859d25d084dde22bf63db0280b3b2f36575f15aa1d6c23acf276c91c2493cf799e3b0
-  languageName: node
-  linkType: hard
-
-"universal-test-renderer@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "universal-test-renderer@npm:0.6.0"
-  dependencies:
-    react-reconciler: "npm:~0.31.0"
-  peerDependencies:
-    react: ^19.0.0
-  checksum: 10/e8583a1a56880ebd5a71b2c71076e469e5a7dbb4f2bb16a714a52a860be363505ec486752abefa07a916ba7efd27d67e04d3ec4fe40db93856f3bdf4cdc0bc60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: N/A (dependency maintenance)

## What I did

Updated `@testing-library/react-native` from `14.0.0-alpha.1` to `14.0.0-beta.0` and migrated from `universal-test-renderer` to `test-renderer`.

### Changes:

- **Upgraded RNTL**: `@testing-library/react-native` `14.0.0-alpha.1` → `14.0.0-beta.0`
- **Replaced test renderer**: Swapped `universal-test-renderer` for `test-renderer@^0.14.0`
- **Updated test files**: Made all `render()` calls async as required by the new RNTL beta (12 test files updated)
- **Cleaned up UI packages**: Removed unused Jest configuration and test-related devDependencies from `react-native-ui`, `react-native-ui-lite`, and `react-native-ui-common`

## How to test

1. Run `yarn install` to update dependencies
2. Run `yarn test` to verify all tests pass with the updated libraries
3. Run tests in the expo-example specifically:
   ```bash
   cd examples/expo-example
   yarn test
   ```

- Does this need a new example in examples/expo-example? **No**
- Does this need an update to the documentation? **No** - this is an internal dependency update with no API changes