### PR TITLE
feat: add Repack/rspack plugin for React Native Storybook

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -24,6 +24,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./metro/withStorybook": "./dist/metro/withStorybook.js",
+    "./repack/withStorybook": "./dist/repack/withStorybook.js",
     "./node": "./dist/node.js",
     "./preview": "./dist/preview.js",
     "./scripts/generate": "./scripts/generate.js",

--- a/packages/react-native/src/repack/withStorybook.ts
+++ b/packages/react-native/src/repack/withStorybook.ts
@@ -1,0 +1,231 @@
+import * as path from 'path';
+import { generate } from '../../scripts/generate';
+import { createChannelServer } from '../metro/channelServer';
+
+/**
+ * Minimal compiler types for webpack/rspack compatibility.
+ * We define these inline to avoid requiring @rspack/core or webpack as dependencies.
+ */
+interface Compiler {
+  options: {
+    resolve: {
+      alias?: Record<string, string | false>;
+    };
+  };
+  hooks: {
+    beforeCompile: {
+      tapPromise: (name: string, fn: () => Promise<void>) => void;
+    };
+  };
+  webpack: {
+    NormalModuleReplacementPlugin: new (
+      pattern: RegExp,
+      fn: (resource: { request?: string }) => void
+    ) => { apply: (compiler: Compiler) => void };
+  };
+}
+
+/**
+ * Options for configuring WebSockets used for syncing storybook instances or sending events to storybook.
+ */
+interface WebsocketsOptions {
+  /**
+   * The port WebSocket server will listen on. Defaults to 7007.
+   */
+  port?: number;
+
+  /**
+   * The host WebSocket server will bind to. Defaults to 'localhost'.
+   */
+  host?: string;
+}
+
+/**
+ * Options for configuring the Storybook Repack plugin.
+ */
+export interface StorybookPluginOptions {
+  /**
+   * The path to the Storybook config folder. Defaults to './.rnstorybook'.
+   */
+  configPath?: string;
+
+  /**
+   * If false, strips Storybook from the bundle. Defaults to true.
+   */
+  enabled?: boolean;
+
+  /**
+   * WebSocket configuration for syncing storybook instances or sending events to storybook.
+   * When set to 'auto', uses port 7007 and auto-detects the host LAN IP address.
+   */
+  websockets?: WebsocketsOptions | 'auto';
+
+  /**
+   * Whether to use JavaScript files for Storybook configuration instead of TypeScript.
+   * When true, generates storybook.requires.js instead of storybook.requires.ts.
+   * Defaults to false.
+   */
+  useJs?: boolean;
+
+  /**
+   * Whether to include doc tools in the storybook.requires file.
+   * Doc tools provide additional documentation features. Defaults to true.
+   */
+  docTools?: boolean;
+
+  /**
+   * Whether to use lite mode for the storybook. In lite mode, the default storybook UI
+   * is mocked out so you don't need to install all its dependencies like reanimated etc.
+   * Defaults to false.
+   */
+  liteMode?: boolean;
+}
+
+/**
+ * Repack/Rspack plugin for React Native Storybook.
+ *
+ * Provides equivalent functionality to the Metro {@link withStorybook} wrapper:
+ * - Auto-generates `storybook.requires.ts` before compilation
+ * - Starts a WebSocket channel server for remote control / syncing
+ * - Supports `enabled: false` to strip Storybook from the bundle
+ * - Supports `liteMode` to mock out the full Storybook UI
+ *
+ * @example
+ * ```javascript
+ * import { StorybookPlugin } from '@storybook/react-native/repack/withStorybook';
+ *
+ * // In your rspack.config.mjs plugins array:
+ * new StorybookPlugin({
+ *   enabled: true,
+ *   websockets: 'auto',
+ * })
+ * ```
+ *
+ * @example
+ * ```javascript
+ * // Disable Storybook in production builds:
+ * new StorybookPlugin({
+ *   enabled: process.env.STORYBOOK_ENABLED !== 'false',
+ *   websockets: 'auto',
+ * })
+ * ```
+ */
+export class StorybookPlugin {
+  private options: Required<
+    Pick<StorybookPluginOptions, 'configPath' | 'enabled' | 'useJs' | 'docTools' | 'liteMode'>
+  > &
+    Pick<StorybookPluginOptions, 'websockets'>;
+
+  private generated = false;
+  private serverStarted = false;
+
+  constructor(options: StorybookPluginOptions = {}) {
+    this.options = {
+      configPath: path.resolve(process.cwd(), './.rnstorybook'),
+      enabled: true,
+      useJs: false,
+      docTools: true,
+      liteMode: false,
+      ...options,
+    };
+  }
+
+  apply(compiler: Compiler): void {
+    const { configPath, enabled, websockets, useJs, docTools, liteMode } = this.options;
+
+    if (!enabled) {
+      this.applyDisabled(compiler, configPath);
+      return;
+    }
+
+    this.applyEnabled(compiler, { configPath, websockets, useJs, docTools, liteMode });
+  }
+
+  /**
+   * When enabled: generate storybook.requires, optionally start websocket server,
+   * and set up liteMode aliases.
+   */
+  private applyEnabled(
+    compiler: Compiler,
+    {
+      configPath,
+      websockets,
+      useJs,
+      docTools,
+      liteMode,
+    }: {
+      configPath: string;
+      websockets?: WebsocketsOptions | 'auto';
+      useJs: boolean;
+      docTools: boolean;
+      liteMode: boolean;
+    }
+  ): void {
+    const port = websockets === 'auto' ? 7007 : (websockets?.port ?? 7007);
+    const host = websockets === 'auto' ? 'auto' : websockets?.host;
+
+    // Start the WebSocket channel server once (on first apply, not per-compilation)
+    if (websockets && !this.serverStarted) {
+      this.serverStarted = true;
+
+      createChannelServer({
+        port,
+        host: host === 'auto' ? undefined : host,
+        configPath,
+      });
+    }
+
+    // Generate storybook.requires before first compilation
+    compiler.hooks.beforeCompile.tapPromise('StorybookPlugin', async () => {
+      if (this.generated) return;
+      this.generated = true;
+
+      await generate({
+        configPath,
+        useJs,
+        docTools,
+        ...(websockets ? { host, port } : {}),
+      });
+
+      console.log('[StorybookPlugin] Generated storybook.requires');
+    });
+
+    // liteMode: alias @storybook/react-native-ui to false (empty module)
+    // but keep @storybook/react-native-ui-lite and @storybook/react-native-ui-common
+    if (liteMode) {
+      const alias = compiler.options.resolve.alias ?? {};
+
+      // rspack/webpack supports `false` as an alias value to produce an empty module.
+      // The `$` suffix ensures exact match so -lite and -common variants are not affected.
+      alias['@storybook/react-native-ui$'] = false;
+
+      compiler.options.resolve.alias = alias;
+    }
+  }
+
+  /**
+   * When disabled: redirect all Storybook imports to empty modules,
+   * and replace the config folder index with a stub component.
+   */
+  private applyDisabled(compiler: Compiler, configPath: string): void {
+    const stubPath = require.resolve('@storybook/react-native/stub');
+    const normalizedConfigPath = path.resolve(configPath);
+
+    // Use NormalModuleReplacementPlugin to intercept storybook module requests
+    new compiler.webpack.NormalModuleReplacementPlugin(/./, (resource) => {
+      const request = resource.request;
+      if (!request) return;
+
+      // Redirect all @storybook/* and storybook imports to the stub
+      if (request.startsWith('@storybook') || request.startsWith('storybook')) {
+        resource.request = stubPath;
+        return;
+      }
+    }).apply(compiler);
+
+    // Alias the config folder's index to the stub component
+    const alias = compiler.options.resolve.alias ?? {};
+    alias[normalizedConfigPath] = stubPath;
+    compiler.options.resolve.alias = alias;
+  }
+}

--- a/packages/react-native/tsup.config.ts
+++ b/packages/react-native/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig((options) => {
       'src/index.ts',
       'src/preview.ts',
       'src/metro/withStorybook.ts',
+      'src/repack/withStorybook.ts',
       'src/stub.tsx',
       'src/node.ts',
     ],
@@ -13,7 +14,7 @@ export default defineConfig((options) => {
     clean: !options.watch,
     dts: !options.watch
       ? {
-          entry: ['src/index.ts', 'src/preview.ts', 'src/metro/withStorybook.ts', 'src/node.ts'],
+          entry: ['src/index.ts', 'src/preview.ts', 'src/metro/withStorybook.ts', 'src/repack/withStorybook.ts', 'src/node.ts'],
           resolve: true,
         }
       : false,

--- a/packages/react-native/tsup.config.ts
+++ b/packages/react-native/tsup.config.ts
@@ -14,7 +14,13 @@ export default defineConfig((options) => {
     clean: !options.watch,
     dts: !options.watch
       ? {
-          entry: ['src/index.ts', 'src/preview.ts', 'src/metro/withStorybook.ts', 'src/repack/withStorybook.ts', 'src/node.ts'],
+          entry: [
+            'src/index.ts',
+            'src/preview.ts',
+            'src/metro/withStorybook.ts',
+            'src/repack/withStorybook.ts',
+            'src/node.ts',
+          ],
           resolve: true,
         }
       : false,


### PR DESCRIPTION
## Summary

- Adds a `StorybookPlugin` class exported at `@storybook/react-native/repack/withStorybook` for projects using [Re.Pack](https://re-pack.dev/) (rspack/webpack) instead of Metro
- Reuses the existing `generate()` and `createChannelServer()` functions — no code duplication with the Metro integration
- Supports all the same options as the Metro `withStorybook` wrapper: `configPath`, `enabled`, `websockets`, `useJs`, `docTools`, `liteMode`

### Usage

```js
import { StorybookPlugin } from '@storybook/react-native/repack/withStorybook';

// In rspack.config.mjs plugins array:
new StorybookPlugin({
  enabled: process.env.STORYBOOK_ENABLED === 'true',
  websockets: 'auto',
})
```

### What the plugin does

| Feature | Implementation |
|---------|---------------|
| **Auto-generation** | `compiler.hooks.beforeCompile.tapPromise` calls `generate()` before first compilation |
| **WebSocket server** | Calls `createChannelServer()` on first `apply()` |
| **`enabled: false`** | `NormalModuleReplacementPlugin` redirects all `@storybook/*` imports to the stub component |
| **`liteMode`** | `resolve.alias` maps `@storybook/react-native-ui$` to `false` (empty module) |

### Tested results (in a Repack example app)

| | `enabled: true` | `enabled: false` |
|---|---|---|
| Bundle size | 6.9 MB | 4.5 MB (34% smaller) |
| Build time | 16.8s | 10.2s (39% faster) |
| Storybook code | Full storybook bundled | Only stub component |

## Test plan

- [x] Verified `enabled: true` generates `storybook.requires.ts`, starts WebSocket server, and produces working bundle
- [x] Verified `enabled: false` strips storybook from bundle, does not start WebSocket server, and produces smaller bundle with stub
- [x] Verified the plugin builds correctly via `tsup` (`yarn prepare`)
- [ ] Run on device with Repack to verify stories render and WebSocket sync works