### PR TITLE
docs: add Re.Pack setup guide to storybook setup skill and handle other rnstorybook index paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Storybook for React Native plugins",
-    "version": "1.0.1"
+    "version": "1.1.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "repo": "storybookjs/react-native"
       },
       "description": "Create and edit React Native Storybook stories using Component Story Format (CSF). Includes controls reference, addon configuration, and portable story patterns.",
-      "version": "1.0.1"
+      "version": "1.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "react-native-storybook",
   "description": "Create and edit React Native Storybook stories using Component Story Format (CSF). Includes controls reference, addon configuration, and portable story patterns.",
-  "version": "1.0.1"
+  "version": "1.1.0"
 }

--- a/packages/react-native/src/metro/withStorybook.ts
+++ b/packages/react-native/src/metro/withStorybook.ts
@@ -177,8 +177,9 @@ export function withStorybook(
 
           const resolved = resolveFunction(context, moduleName, platform);
 
-          // TODO do i need to account for jsx/js/ts file
-          if (resolved.filePath?.includes?.(`${configPath}/index.tsx`)) {
+          // Match the config folder's index file regardless of extension (ts, tsx, js, jsx)
+          const configIndexRegex = new RegExp(`${configPath}/index\\.(tsx?|jsx?)$`);
+          if (resolved.filePath && configIndexRegex.test(resolved.filePath)) {
             return {
               filePath: path.resolve(__dirname, '../stub.js'),
               type: 'sourceFile',

--- a/skills/setup-react-native-storybook/SKILL.md
+++ b/skills/setup-react-native-storybook/SKILL.md
@@ -37,7 +37,33 @@ npm create storybook -- --type react_native --yes
 
 This installs dependencies and creates `.rnstorybook/` with `main.ts`, `preview.tsx`, and `index.tsx`.
 
-### 2. Update Story Globs in main.ts
+### 2. Enable WebSockets in .rnstorybook/index.tsx
+
+Update the generated `.rnstorybook/index.tsx` to enable WebSocket support. This is required for remote control and syncing with the Storybook web companion:
+
+```tsx
+// .rnstorybook/index.tsx
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { view } from './storybook.requires';
+
+const StorybookUIRoot = view.getStorybookUI({
+  storage: {
+    getItem: AsyncStorage.getItem,
+    setItem: AsyncStorage.setItem,
+  },
+  enableWebsockets: true,
+});
+
+export default StorybookUIRoot;
+```
+
+If the project doesn't have `@react-native-async-storage/async-storage`, install it:
+
+```bash
+npm install @react-native-async-storage/async-storage
+```
+
+### 3. Update Story Globs in main.ts
 
 The CLI generates a default `stories` glob in `.rnstorybook/main.ts`. Keep the existing glob and add an additional entry pointing to where UI components actually live in the project. Look for directories like `components/`, `src/components/`, `src/`, `ui/`, etc.:
 
@@ -52,15 +78,15 @@ const main: StorybookConfig = {
 };
 ```
 
-### 3. Configure Bundler
+### 4. Configure Bundler
 
 For Metro projects, wrap the metro config with `withStorybook`. For Re.Pack projects, add the `StorybookPlugin` to your rspack/webpack config. See the relevant reference file for details.
 
-### 4. Create Entrypoint
+### 5. Create Entrypoint
 
 How Storybook is rendered differs per flow - see the relevant reference file.
 
-### 5. Run
+### 6. Run
 
 ```bash
 npm run start

--- a/skills/setup-react-native-storybook/SKILL.md
+++ b/skills/setup-react-native-storybook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-react-native-storybook
-description: Set up Storybook for React Native in Expo or React Native CLI projects. Use when adding Storybook to a project, configuring metro.config.js with withStorybook, creating .rnstorybook configuration files, setting up Storybook routes in Expo Router, or configuring getStorybookUI. Covers Expo, Expo Router, and plain React Native CLI setups.
+description: Set up Storybook for React Native in Expo, React Native CLI, or Re.Pack projects. Use when adding Storybook to a project, configuring metro.config.js with withStorybook, creating .rnstorybook configuration files, setting up Storybook routes in Expo Router, configuring getStorybookUI, or adding the StorybookPlugin to a Re.Pack rspack/webpack config. Covers Expo, Expo Router, plain React Native CLI, and Re.Pack setups.
 ---
 
 # React Native Storybook Setup
@@ -11,14 +11,16 @@ Add `@storybook/react-native` v10 to a React Native project.
 
 For the init command, use `<pm> create storybook` with the flags shown below. Only npm needs `--` before the flags. Never use `npx`/`bunx` etc for this.
 
-Three setup flows based on project type:
+Four setup flows based on project type:
 
 1. **Expo (no router)** - see [references/expo-setup.md](references/expo-setup.md)
 2. **Expo with Expo Router** - see [references/expo-router-setup.md](references/expo-router-setup.md)
 3. **React Native CLI (no Expo)** - see [references/react-native-cli-setup.md](references/react-native-cli-setup.md)
+4. **Re.Pack (rspack/webpack)** - see [references/repack-setup.md](references/repack-setup.md)
 
 ## Flow Selection
 
+- Project has `rspack.config` or `webpack.config` and uses `@callstack/repack` -> **Re.Pack**
 - Project has `app/` directory with `_layout.tsx` and uses `expo-router` -> **Expo Router**
 - Project uses Expo but not file-based routing -> **Expo**
 - Project uses `@react-native-community/cli` with no Expo -> **React Native CLI**
@@ -50,9 +52,9 @@ const main: StorybookConfig = {
 };
 ```
 
-### 3. Configure Metro
+### 3. Configure Bundler
 
-Wrap the metro config with `withStorybook`. The specific metro config differs per flow - see the relevant reference file.
+For Metro projects, wrap the metro config with `withStorybook`. For Re.Pack projects, add the `StorybookPlugin` to your rspack/webpack config. See the relevant reference file for details.
 
 ### 4. Create Entrypoint
 
@@ -65,7 +67,7 @@ npm run start
 npm run ios     # or npm run android
 ```
 
-## withStorybook Options
+## withStorybook Options (Metro)
 
 ```js
 module.exports = withStorybook(config, {
@@ -75,5 +77,18 @@ module.exports = withStorybook(config, {
   docTools: true, // Auto arg extraction
   liteMode: false, // Mock default UI deps (use with react-native-ui-lite)
   websockets: { port: 7007, host: 'localhost' }, // Remote control
+});
+```
+
+## StorybookPlugin Options (Re.Pack)
+
+```js
+new StorybookPlugin({
+  enabled: true, // Strip Storybook from bundle when false
+  configPath: './.rnstorybook', // Storybook config directory
+  useJs: false, // Generate .js instead of .ts
+  docTools: true, // Auto arg extraction
+  liteMode: false, // Mock default UI deps (use with react-native-ui-lite)
+  websockets: 'auto', // 'auto' detects LAN IP, or { port: 7007, host: 'localhost' }
 });
 ```

--- a/skills/setup-react-native-storybook/references/repack-setup.md
+++ b/skills/setup-react-native-storybook/references/repack-setup.md
@@ -50,6 +50,11 @@ const storybookEnabled = process.env.STORYBOOK_ENABLED === 'true';
 
 export default Repack.defineRspackConfig({
   // ... your existing config
+  resolve: {
+    ...Repack.getResolveOptions({
+      enablePackageExports: true, // required for storybook package resolution
+    }),
+  },
   plugins: [
     new Repack.RepackPlugin(),
     new rspack.DefinePlugin({
@@ -64,7 +69,9 @@ export default Repack.defineRspackConfig({
 });
 ```
 
-**Note:** Unlike the Metro setup, there is no need to configure `require.context` support or package exports — rspack handles both natively.
+**Important:** `enablePackageExports: true` is required so rspack can correctly resolve Storybook's package exports (e.g. `@storybook/react-native/preview`). Without it, imports from Storybook packages will fail.
+
+**Note:** Unlike the Metro setup, there is no need to configure `require.context` support — rspack handles it natively.
 
 ## Step 4: Create Entrypoint
 

--- a/skills/setup-react-native-storybook/references/repack-setup.md
+++ b/skills/setup-react-native-storybook/references/repack-setup.md
@@ -18,6 +18,22 @@ npm install react-native-reanimated react-native-worklets
 
 Verify both are in `package.json` dependencies before proceeding.
 
+Then ensure the worklets babel plugin is in `babel.config.js`. It **must** be the last plugin in the list:
+
+```js
+// babel.config.js
+module.exports = {
+  presets: [
+    // your existing preset, e.g.:
+    'module:@react-native/babel-preset',
+  ],
+  plugins: [
+    // ... any other plugins
+    'react-native-worklets/plugin', // must be last
+  ],
+};
+```
+
 ## Step 3: Configure the Rspack/Webpack Config
 
 Instead of wrapping Metro with `withStorybook`, add the `StorybookPlugin` to your rspack/webpack config plugins array.

--- a/skills/setup-react-native-storybook/references/repack-setup.md
+++ b/skills/setup-react-native-storybook/references/repack-setup.md
@@ -1,0 +1,106 @@
+# Re.Pack (Rspack/Webpack) Setup
+
+For React Native projects using [Re.Pack](https://re-pack.dev/) instead of Metro as the bundler.
+
+## Step 1: Run CLI Init
+
+```bash
+npm create storybook -- --type react_native --yes
+```
+
+## Step 2: Ensure react-native-worklets is installed
+
+Storybook's default UI depends on `react-native-reanimated` and `react-native-worklets`. If they're not already installed:
+
+```bash
+npm install react-native-reanimated react-native-worklets
+```
+
+## Step 3: Configure the Rspack/Webpack Config
+
+Instead of wrapping Metro with `withStorybook`, add the `StorybookPlugin` to your rspack/webpack config plugins array.
+
+Use an environment variable (`STORYBOOK_ENABLED`) to control both the plugin behavior and a build-time constant for your app code:
+
+```js
+// rspack.config.mjs
+import * as Repack from '@callstack/repack';
+import rspack from '@rspack/core';
+import { StorybookPlugin } from '@storybook/react-native/repack/withStorybook';
+
+const storybookEnabled = process.env.STORYBOOK_ENABLED === 'true';
+
+export default Repack.defineRspackConfig({
+  // ... your existing config
+  plugins: [
+    new Repack.RepackPlugin(),
+    new rspack.DefinePlugin({
+      STORYBOOK_ENABLED: JSON.stringify(storybookEnabled),
+    }),
+    new StorybookPlugin({
+      enabled: storybookEnabled,
+      websockets: 'auto',
+    }),
+    // ... your other plugins
+  ],
+});
+```
+
+**Note:** Unlike the Metro setup, there is no need to configure `require.context` support or package exports — rspack handles both natively.
+
+## Step 4: Create Entrypoint
+
+Conditionally render Storybook based on the `STORYBOOK_ENABLED` build-time constant. Since `StorybookPlugin` replaces Storybook imports with empty modules when disabled, you can import Storybook at the top level safely:
+
+```tsx
+// App.tsx
+import StorybookUI from './.rnstorybook';
+
+declare const STORYBOOK_ENABLED: boolean;
+
+export default function App() {
+  if (STORYBOOK_ENABLED) {
+    return <StorybookUI />;
+  }
+
+  // Your existing app code here
+  return (
+    // ...
+  );
+}
+```
+
+The `declare const` tells TypeScript about the global that rspack's `DefinePlugin` injects. When `STORYBOOK_ENABLED` is `false`, rspack dead-code-eliminates the Storybook branch entirely.
+
+## Step 5: Add Scripts
+
+```json
+{
+  "scripts": {
+    "storybook": "STORYBOOK_ENABLED='true' rock start",
+    "storybook:ios": "STORYBOOK_ENABLED='true' rock run:ios",
+    "storybook:android": "STORYBOOK_ENABLED='true' rock run:android"
+  }
+}
+```
+
+Replace `rock` with `react-native` or your project's CLI if not using Rock.
+
+## Step 6: Run
+
+```bash
+npm run storybook
+```
+
+## StorybookPlugin Options
+
+```js
+new StorybookPlugin({
+  enabled: true, // Strip Storybook from bundle when false
+  configPath: './.rnstorybook', // Storybook config directory
+  useJs: false, // Generate .js instead of .ts
+  docTools: true, // Auto arg extraction
+  liteMode: false, // Mock default UI deps (use with react-native-ui-lite)
+  websockets: 'auto', // 'auto' detects LAN IP, or { port: 7007, host: 'localhost' }
+});
+```

--- a/skills/setup-react-native-storybook/references/repack-setup.md
+++ b/skills/setup-react-native-storybook/references/repack-setup.md
@@ -8,13 +8,15 @@ For React Native projects using [Re.Pack](https://re-pack.dev/) instead of Metro
 npm create storybook -- --type react_native --yes
 ```
 
-## Step 2: Ensure react-native-worklets is installed
+## Step 2: Install react-native-reanimated and react-native-worklets
 
-Storybook's default UI depends on `react-native-reanimated` and `react-native-worklets`. If they're not already installed:
+Storybook's default UI requires both `react-native-reanimated` and `react-native-worklets`. Re.Pack projects often already have `react-native-reanimated` but **`react-native-worklets` must also be installed separately** — it is not bundled with reanimated:
 
 ```bash
 npm install react-native-reanimated react-native-worklets
 ```
+
+Verify both are in `package.json` dependencies before proceeding.
 
 ## Step 3: Configure the Rspack/Webpack Config
 


### PR DESCRIPTION
## Summary

- Adds a new reference file (`references/repack-setup.md`) for setting up React Native Storybook with Re.Pack (rspack/webpack) using the `StorybookPlugin`
- Updates the skill description and flow selection to include Re.Pack as a fourth project type
- Renames "Configure Metro" common step to "Configure Bundler" to be bundler-agnostic
- Adds `StorybookPlugin Options (Re.Pack)` section alongside the existing `withStorybook Options (Metro)`

## Test plan

- [ ] Verify skill triggers correctly when a project has `rspack.config` and `@callstack/repack`
- [ ] Verify the repack-setup.md steps are accurate against the StorybookPlugin implementation