### PR TITLE
fix: crash on websocket in use

### DIFF
--- a/.changeset/wide-bears-invent.md
+++ b/.changeset/wide-bears-invent.md
@@ -1,0 +1,5 @@
+---
+'@storybook/react-native': patch
+---
+
+fix: prevent crash when websocket port is in use

--- a/packages/react-native/src/metro/channelServer.ts
+++ b/packages/react-native/src/metro/channelServer.ts
@@ -93,6 +93,11 @@ export function createChannelServer({
 
   const wss = new WebSocketServer({ server: httpServer });
 
+  wss.on('error', () => {
+    // Handled by httpServer 'error' listener — this prevents the WSS
+    // from re-throwing and crashing the process.
+  });
+
   // Single global ping interval for all clients
   setInterval(function ping() {
     wss.clients.forEach(function each(client) {
@@ -116,6 +121,17 @@ export function createChannelServer({
         console.error(error);
       }
     });
+  });
+
+  httpServer.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.code === 'EADDRINUSE') {
+      console.warn(
+        `[Storybook] Port ${port} is already in use. The channel server will not start. ` +
+          `Another instance may already be running.`
+      );
+    } else {
+      console.error(`[Storybook] Channel server error:`, error);
+    }
   });
 
   httpServer.listen(port, host, () => {


### PR DESCRIPTION
Issue:

## What I did
prevent crashes for port clashes

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
