### PR TITLE
fix: stub Reanimated globals on web to unblock fn() actions

### DIFF
--- a/.changeset/warm-walls-wish.md
+++ b/.changeset/warm-walls-wish.md
@@ -1,0 +1,5 @@
+---
+'@storybook/react-native': patch
+---
+
+fix invalid reanimated globals breaking actions on web

--- a/.changeset/wide-jobs-wink.md
+++ b/.changeset/wide-jobs-wink.md
@@ -1,0 +1,11 @@
+---
+'@storybook/addon-ondevice-actions': patch
+'@storybook/addon-ondevice-backgrounds': patch
+'@storybook/addon-ondevice-controls': patch
+'@storybook/addon-ondevice-notes': patch
+'@storybook/react-native-ui': patch
+'@storybook/react-native-ui-common': patch
+'@storybook/react-native-ui-lite': patch
+---
+
+update dev deps and lock to fix duplicate deps

--- a/packages/react-native/src/preview.ts
+++ b/packages/react-native/src/preview.ts
@@ -1,8 +1,19 @@
+import { Platform } from 'react-native';
 import {
   parameters as reactParameters,
   argTypesEnhancers,
 } from '@storybook/react/entry-preview-docs';
 import { type Preview } from '@storybook/react';
+
+// Workaround for Reanimated globals not being available on web.
+// Without these, the actions panel crashes with:
+// "ProgressTransitionRegister is not available on non-native platform"
+if (Platform.OS === 'web') {
+  // @ts-ignore
+  globalThis.ProgressTransitionRegister = {};
+  // @ts-ignore
+  globalThis.UpdatePropsManager = {};
+}
 
 const preview: Preview = {
   argTypesEnhancers,


### PR DESCRIPTION
## Summary

- Stubs `ProgressTransitionRegister` and `UpdatePropsManager` globals on web platform in `preview.ts`
- These Reanimated globals are not available on web and their absence was silently preventing `fn()` from `storybook/test` from triggering actions

## Problem

When running on web, the missing Reanimated globals caused `fn()` mocks to not fire, so actions using `storybook/test` `fn()` would silently fail to appear in the actions panel.

## Test plan

- [ ] Run the expo example on web
- [ ] Verify actions using `fn()` from `storybook/test` trigger and appear in the actions panel
- [ ] Verify no regressions on native (iOS/Android) — the stubs are web-only