### PR TITLE
fix: snapshot RN synthetic events and prevent channel echo

### DIFF
--- a/packages/react-native/src/View.tsx
+++ b/packages/react-native/src/View.tsx
@@ -8,6 +8,7 @@ import { addons as managerAddons } from 'storybook/manager-api';
 import { PreviewWithSelection, addons as previewAddons } from 'storybook/internal/preview-api';
 import type { API_IndexHash, PreparedStory, StoryId, StoryIndex } from 'storybook/internal/types';
 import dedent from 'dedent';
+import { patchChannelForRN } from './patchChannelForRN';
 import deepmerge from 'deepmerge';
 import { useEffect, useMemo, useReducer, useState } from 'react';
 import {
@@ -202,14 +203,15 @@ export class View {
     const url = `${websocketType}://${host}${port}/${query}`;
 
     const channel = new Channel({
+      async: true,
       transport: new WebsocketTransport({
         url,
         onError: (e) => {
           console.log(`WebsocketTransport error ${JSON.stringify(e)}`);
         },
       }),
-      async: true,
     });
+    patchChannelForRN(channel);
 
     return channel;
   };

--- a/packages/react-native/src/metro/channelServer.ts
+++ b/packages/react-native/src/metro/channelServer.ts
@@ -148,8 +148,13 @@ export function createChannelServer({
       ws.on('message', function message(data: Data) {
         try {
           const json = JSON.parse(data.toString());
+          const msg = JSON.stringify(json);
 
-          wss.clients.forEach((wsClient) => wsClient.send(JSON.stringify(json)));
+          wss.clients.forEach((wsClient) => {
+            if (wsClient !== ws && wsClient.readyState === WebSocket.OPEN) {
+              wsClient.send(msg);
+            }
+          });
         } catch (error) {
           console.error(error);
         }

--- a/packages/react-native/src/patchChannelForRN.ts
+++ b/packages/react-native/src/patchChannelForRN.ts
@@ -1,0 +1,81 @@
+import type { Channel } from 'storybook/internal/channels';
+
+/**
+ * React Native still pools synthetic events (unlike React DOM 17+).
+ * Storybook's serializeArg only recognises web SyntheticBaseEvent, so RN
+ * events pass through raw. When anything reads their properties after the
+ * current call-stack (render, transport stringify), the event has already
+ * been returned to the pool and every getter throws the "reused for
+ * performance reasons" warning.
+ *
+ * Instead of calling persist() (which keeps the event alive and retains
+ * references to native views), we snapshot the event into a plain object.
+ * This is safe for later access, serialization, and deep-equality checks.
+ */
+function snapshotValue(value: unknown, depth = 0): unknown {
+  if (depth > 3) return '[...]';
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'function') return undefined;
+  if (typeof value !== 'object') return value;
+
+  if (Array.isArray(value)) {
+    return value.map((item) => snapshotValue(item, depth + 1));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    try {
+      result[key] = snapshotValue((value as Record<string, unknown>)[key], depth + 1);
+    } catch {
+      result[key] = '[Error]';
+    }
+  }
+  return result;
+}
+
+function isSyntheticEvent(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as any).persist === 'function' &&
+    'nativeEvent' in (value as any)
+  );
+}
+
+function sanitizeActionArgs(value: unknown): unknown {
+  if (isSyntheticEvent(value)) {
+    return snapshotValue(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeActionArgs);
+  }
+  return value;
+}
+
+/**
+ * Patch a Channel so that action-event payloads have their RN synthetic
+ * events replaced with plain-object snapshots synchronously, before React
+ * recycles them back into the event pool.
+ */
+export function patchChannelForRN(channel: Channel): void {
+  /**
+   * Limit WebSocket serialization depth to avoid circular reference errors
+   * when action args contain React fiber nodes or other deep object graphs.
+   * The default maxDepth of 15 is too deep and causes blocking + crashes.
+   */
+  globalThis.CHANNEL_OPTIONS = {
+    maxDepth: 5,
+  };
+
+  const originalEmit = channel.emit.bind(channel);
+
+  channel.emit = (eventName: string, ...args: any[]) => {
+    if (eventName === 'storybook/actions/action-event') {
+      const actionDisplay = args[0];
+      if (actionDisplay?.data?.args != null) {
+        actionDisplay.data.args = sanitizeActionArgs(actionDisplay.data.args);
+      }
+    }
+    return originalEmit(eventName, ...args);
+  };
+}

--- a/packages/react-native/src/polyfill.ts
+++ b/packages/react-native/src/polyfill.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'react-native-web';
+import { Platform } from 'react-native';
 
 if (Platform.OS !== 'web') {
   // We polyfill URLSearchParams for React Native since URLSearchParams.get is not implemented yet is used in storybook
@@ -13,4 +13,9 @@ if (Platform.OS !== 'web') {
 
     setupURLPolyfill();
   }
+}
+
+// Note this is a workaround for setImmediate not being defined
+if (Platform.OS === 'web' && typeof globalThis.setImmediate === 'undefined') {
+  require('setimmediate');
 }


### PR DESCRIPTION
## Summary

- Adds `patchChannelForRN` which snapshots React Native synthetic event args synchronously before React recycles them back to the event pool
- Limits WebSocket channel serialization depth to 5 to prevent circular reference crashes from deep object graphs (React fiber nodes etc.)
- Stops the WebSocket server from echoing messages back to the sender, preventing duplicate event handling
- Fixes `polyfill.ts` import from `react-native-web` to `react-native`
- Moves `setImmediate` workaround from `Start.tsx` to `polyfill.ts` where it belongs

## Problem

React Native still pools synthetic events (unlike React DOM 17+). When action events containing synthetic event args were serialized asynchronously by the channel transport, the events had already been returned to the pool — causing stale event warnings, serialization errors, or crashes from circular references in deep object graphs.

Additionally, the WebSocket server was broadcasting messages back to the sender, causing duplicate event processing.

## Test plan

- [ ] Run the expo example on device
- [ ] Trigger actions (button presses, text input, etc.)
- [ ] Verify action events display clean data in the actions panel without warnings or crashes
- [ ] Verify actions don't double-trigger