### PR TITLE
fix: keep addon panels mounted when inactive

### DIFF
--- a/.changeset/light-squids-speak.md
+++ b/.changeset/light-squids-speak.md
@@ -1,0 +1,10 @@
+---
+'@storybook/addon-ondevice-backgrounds': patch
+'@storybook/react-native-ui-lite': patch
+'@storybook/addon-ondevice-controls': patch
+'@storybook/react-native-ui': patch
+'@storybook/addon-ondevice-notes': patch
+'@storybook/react-native': patch
+---
+
+fix: addon panels only update when active

--- a/.changeset/public-impalas-begin.md
+++ b/.changeset/public-impalas-begin.md
@@ -1,0 +1,5 @@
+---
+'@storybook/react-native': patch
+---
+
+fix: snapshot RN synthetic events and prevent channel echo

--- a/packages/ondevice-backgrounds/src/BackgroundPanel.tsx
+++ b/packages/ondevice-backgrounds/src/BackgroundPanel.tsx
@@ -66,10 +66,6 @@ interface BackgroundPanelProps {
 }
 
 const BackgroundPanel = ({ active, api, channel }: BackgroundPanelProps) => {
-  if (!active) {
-    return null;
-  }
-
   const store = api.store();
   const storyId = store.getSelection().storyId;
   const story = store.fromId(storyId);

--- a/packages/ondevice-controls/src/Panel.tsx
+++ b/packages/ondevice-controls/src/Panel.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
 export const AddonPanel = ({ active, children }) => {
-  if (!active) {
-    return null;
-  }
   return <>{children}</>;
 };
 

--- a/packages/ondevice-notes/src/components/Notes.tsx
+++ b/packages/ondevice-notes/src/components/Notes.tsx
@@ -73,7 +73,7 @@ export const Notes = ({ active, api }: NotesProps) => {
     [theme.color.defaultText, theme.background.app]
   );
 
-  if (!active || !story) {
+  if (!story) {
     return null;
   }
 

--- a/packages/react-native-ui-lite/src/MobileAddonsPanel.tsx
+++ b/packages/react-native-ui-lite/src/MobileAddonsPanel.tsx
@@ -14,7 +14,11 @@ import {
   ViewStyle,
 } from 'react-native';
 import { addons } from 'storybook/manager-api';
-import { Addon_TypesEnum } from 'storybook/internal/types';
+import {
+  Addon_TypesEnum,
+  type Addon_BaseType,
+  type Addon_Collection,
+} from 'storybook/internal/types';
 import { CloseIcon } from './icon/iconDataUris';
 import useAnimatedValue from './useAnimatedValue';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -214,32 +218,18 @@ const centeredStyle = {
   justifyContent: 'center',
 } satisfies StyleProp<ViewStyle>;
 
+const hiddenStyle = {
+  display: 'none',
+} satisfies StyleProp<ViewStyle>;
+
 const hitSlop = { top: 10, right: 10, bottom: 10, left: 10 };
 
 export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId?: string }) => {
-  const panels = addons.getElements(Addon_TypesEnum.PANEL);
+  const panels: Addon_Collection<Addon_BaseType> = addons.getElements(Addon_TypesEnum.PANEL);
   const insets = useSafeAreaInsets();
   const [addonSelected, setAddonSelected] = useState(Object.keys(panels)[0]);
 
-  const panel = useMemo(() => {
-    if (!storyId) {
-      return (
-        <View style={centeredStyle}>
-          <Text>No Story Selected</Text>
-        </View>
-      );
-    }
-
-    if (Object.keys(panels).length === 0) {
-      return (
-        <View style={centeredStyle}>
-          <Text>No addons loaded.</Text>
-        </View>
-      );
-    }
-
-    return panels[addonSelected].render({ active: true });
-  }, [addonSelected, panels, storyId]);
+  const panelEntries = useMemo(() => Object.entries(panels), [panels]);
 
   const scrollContentContainerStyle = useStyle(
     () => ({
@@ -265,7 +255,7 @@ export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId
                 key={id}
                 active={id === addonSelected}
                 onPress={() => setAddonSelected(id)}
-                text={resolvedTitle}
+                text={String(resolvedTitle)}
               />
             );
           })}
@@ -285,10 +275,28 @@ export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId
         // keyboardShouldPersistTaps="handled"
         contentContainerStyle={scrollContentContainerStyle}
       >
-        {panel}
+        {!storyId ? (
+          <View style={centeredStyle}>
+            <Text>No Story Selected</Text>
+          </View>
+        ) : panelEntries.length === 0 ? (
+          <View style={centeredStyle}>
+            <Text>No addons loaded.</Text>
+          </View>
+        ) : (
+          panelEntries.map(([id, p]) => (
+            <View key={id} style={id === addonSelected ? undefined : hiddenStyle}>
+              <PanelRenderer panel={p} />
+            </View>
+          ))
+        )}
       </ScrollView>
     </View>
   );
+};
+
+const PanelRenderer = ({ panel }: { panel: Addon_BaseType }) => {
+  return panel.render({ active: true });
 };
 
 const Tab = ({ active, onPress, text }: { active: boolean; onPress: () => void; text: string }) => {

--- a/packages/react-native-ui/src/MobileAddonsPanel.tsx
+++ b/packages/react-native-ui/src/MobileAddonsPanel.tsx
@@ -1,7 +1,11 @@
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { addons } from 'storybook/manager-api';
 import { styled, useTheme } from '@storybook/react-native-theming';
-import { Addon_TypesEnum } from 'storybook/internal/types';
+import {
+  Addon_TypesEnum,
+  type Addon_BaseType,
+  type Addon_Collection,
+} from 'storybook/internal/types';
 import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Platform, StyleProp, Text, View, ViewStyle, useWindowDimensions } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
@@ -138,10 +142,14 @@ const centeredStyle = {
   justifyContent: 'center',
 } satisfies StyleProp<ViewStyle>;
 
+const hiddenStyle = {
+  display: 'none',
+} satisfies StyleProp<ViewStyle>;
+
 const hitSlop = { top: 10, right: 10, bottom: 10, left: 10 };
 
 export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId?: string }) => {
-  const panels = addons.getElements(Addon_TypesEnum.PANEL);
+  const panels: Addon_Collection<Addon_BaseType> = addons.getElements(Addon_TypesEnum.PANEL);
 
   const [addonSelected, setAddonSelected] = useState(Object.keys(panels)[0]);
 
@@ -153,25 +161,7 @@ export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId
     };
   });
 
-  const panel = useMemo(() => {
-    if (!storyId) {
-      return (
-        <View style={centeredStyle}>
-          <Text>No Story Selected</Text>
-        </View>
-      );
-    }
-
-    if (Object.keys(panels).length === 0) {
-      return (
-        <View style={centeredStyle}>
-          <Text>No addons loaded.</Text>
-        </View>
-      );
-    }
-
-    return panels[addonSelected].render({ active: true });
-  }, [addonSelected, panels, storyId]);
+  const panelEntries = useMemo(() => Object.entries(panels), [panels]);
 
   return (
     <View style={addonsTabsContainerStyle}>
@@ -189,7 +179,7 @@ export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId
                 key={id}
                 active={id === addonSelected}
                 onPress={() => setAddonSelected(id)}
-                text={resolvedTitle}
+                text={String(resolvedTitle)}
               />
             );
           })}
@@ -207,10 +197,28 @@ export const AddonsTabs = ({ onClose, storyId }: { onClose?: () => void; storyId
         // keyboardShouldPersistTaps="handled"
         contentContainerStyle={scrollContentContainerStyle}
       >
-        {panel}
+        {!storyId ? (
+          <View style={centeredStyle}>
+            <Text>No Story Selected</Text>
+          </View>
+        ) : panelEntries.length === 0 ? (
+          <View style={centeredStyle}>
+            <Text>No addons loaded.</Text>
+          </View>
+        ) : (
+          panelEntries.map(([id, p]) => (
+            <View key={id} style={id === addonSelected ? undefined : hiddenStyle}>
+              <PanelRenderer panel={p} />
+            </View>
+          ))
+        )}
       </ScrollView>
     </View>
   );
+};
+
+const PanelRenderer = ({ panel }: { panel: Addon_BaseType }) => {
+  return panel.render({ active: true });
 };
 
 const Tab = ({ active, onPress, text }: { active: boolean; onPress: () => void; text: string }) => {

--- a/packages/react-native/src/backgrounds/BackgroundPanel.tsx
+++ b/packages/react-native/src/backgrounds/BackgroundPanel.tsx
@@ -82,8 +82,8 @@ interface BackgroundOptions {
 
 const BackgroundPanel = ({ active, api, channel }: BackgroundPanelProps) => {
   const store = api.store();
-  const storyId = store.getSelection().storyId;
-  const story = store.fromId(storyId);
+  const storyId = store.getSelection()?.storyId;
+  const story = storyId ? store.fromId(storyId) : null;
 
   // storyGlobals comes from PreparedStory spread in getStoryContext
   const isLocked = !!story?.storyGlobals?.[PARAM_KEY];
@@ -95,13 +95,8 @@ const BackgroundPanel = ({ active, api, channel }: BackgroundPanelProps) => {
     [channel]
   );
 
-  if (!active) {
-    return null;
-  }
-
-  const bgParams = story.parameters[PARAM_KEY];
+  const bgParams = story?.parameters?.[PARAM_KEY];
   const options: BackgroundOptions | undefined = bgParams?.options;
-
   if (options && Object.keys(options).length > 0) {
     return (
       <View style={{ padding: 10 }}>


### PR DESCRIPTION
## Summary

- All addon panels are now always rendered and hidden with `display: none` when inactive, instead of returning `null` and unmounting
- Applies to both `react-native-ui` and `react-native-ui-lite` MobileAddonsPanel implementations
- Removes early `!active` return guards from BackgroundPanel, controls Panel, and Notes

## Problem

Previously, switching addon tabs would unmount the inactive panel and lose its state. This meant:
- Actions logged while viewing another tab were lost
- Panels had to re-initialize every time they became active
- Any in-progress state (e.g. control edits) was discarded on tab switch

## Test plan

- [ ] Run the expo example, trigger some actions, then switch to the controls tab and back — actions should still be there
- [ ] Switch between all addon tabs — no crashes or blank panels
- [ ] Verify backgrounds, controls, and notes panels all render correctly when selected
- [ ] Test on both full UI and lite UI modes