### PR TITLE
Add React Native Storybook upgrade agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ This repo includes agent skills for setting up and working with Storybook for Re
 
 - **writing-react-native-storybook-stories** - Guides Claude on writing stories using Component Story Format (CSF), including controls, addons, decorators, parameters, and portable stories
 - **setup-react-native-storybook** - Guides Claude through adding Storybook to your project, covering Expo, Expo Router, React Native CLI, and Re.Pack setups
+- **upgrading-react-native-storybook** - Guides Claude through incremental React Native Storybook upgrades, split by supported migration paths from 5.3.x through 10.x, including converting remaining `storiesOf` stories to CSF during the 6.5.x to 7.6.x migration
 
 ### Installation
 

--- a/docs/docs/intro/getting-started/index.md
+++ b/docs/docs/intro/getting-started/index.md
@@ -23,6 +23,7 @@ npx skills add storybookjs/react-native
 ```
 
 The **setup-react-native-storybook** skill walks your agent through the full setup for Expo, Expo Router, React Native CLI, and Re.Pack projects.
+The **upgrading-react-native-storybook** skill handles supported version-to-version migrations one hop at a time instead of attempting a full jump in one pass.
 :::
 
 ## Recommended setup

--- a/packages/react-native/readme.md
+++ b/packages/react-native/readme.md
@@ -574,6 +574,7 @@ This repo includes agent skills for setting up and working with Storybook for Re
 
 - **writing-react-native-storybook-stories** - Guides Claude on writing stories using Component Story Format (CSF), including controls, addons, decorators, parameters, and portable stories
 - **setup-react-native-storybook** - Guides Claude through adding Storybook to your project, covering Expo, Expo Router, React Native CLI, and Re.Pack setups
+- **upgrading-react-native-storybook** - Guides Claude through incremental React Native Storybook upgrades, split by supported migration paths from 5.3.x through 10.x, including converting remaining `storiesOf` stories to CSF during the 6.5.x to 7.6.x migration
 
 ### Installation
 

--- a/skills/setup-react-native-storybook/SKILL.md
+++ b/skills/setup-react-native-storybook/SKILL.md
@@ -98,7 +98,7 @@ npm run ios     # or npm run android
 ```js
 module.exports = withStorybook(config, {
   enabled: true, // Remove Storybook from bundle when false
-  configPath: './storybook-native', // Optional: only set this when not using the default ./.rnstorybook folder
+  configPath: './.rnstorybook', // Optional and redundant when using the default ./.rnstorybook folder
   useJs: false, // Generate .js instead of .ts
   docTools: true, // Auto arg extraction
   liteMode: false, // Mock default UI deps (use with react-native-ui-lite)
@@ -111,7 +111,7 @@ module.exports = withStorybook(config, {
 ```js
 new StorybookPlugin({
   enabled: true, // Strip Storybook from bundle when false
-  configPath: './storybook-native', // Optional: only set this when not using the default ./.rnstorybook folder
+  configPath: './.rnstorybook', // Optional and redundant when using the default ./.rnstorybook folder
   useJs: false, // Generate .js instead of .ts
   docTools: true, // Auto arg extraction
   liteMode: false, // Mock default UI deps (use with react-native-ui-lite)

--- a/skills/setup-react-native-storybook/SKILL.md
+++ b/skills/setup-react-native-storybook/SKILL.md
@@ -98,7 +98,7 @@ npm run ios     # or npm run android
 ```js
 module.exports = withStorybook(config, {
   enabled: true, // Remove Storybook from bundle when false
-  configPath: './.rnstorybook', // Storybook config directory
+  configPath: './storybook-native', // Optional: only set this when not using the default ./.rnstorybook folder
   useJs: false, // Generate .js instead of .ts
   docTools: true, // Auto arg extraction
   liteMode: false, // Mock default UI deps (use with react-native-ui-lite)
@@ -111,7 +111,7 @@ module.exports = withStorybook(config, {
 ```js
 new StorybookPlugin({
   enabled: true, // Strip Storybook from bundle when false
-  configPath: './.rnstorybook', // Storybook config directory
+  configPath: './storybook-native', // Optional: only set this when not using the default ./.rnstorybook folder
   useJs: false, // Generate .js instead of .ts
   docTools: true, // Auto arg extraction
   liteMode: false, // Mock default UI deps (use with react-native-ui-lite)

--- a/skills/upgrading-react-native-storybook/SKILL.md
+++ b/skills/upgrading-react-native-storybook/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: upgrading-react-native-storybook
+description: Incrementally upgrade React Native Storybook across the supported migration paths. Use when upgrading `@storybook/react-native` projects from 5.3.x to 6.5.x, 6.5.x to 7.6.x, 7.6.x to 8.3.x, 8.x to 9.x, or 9.x to 10.x. Detect the currently installed Storybook version, choose only the next migration step, update dependencies and config, regenerate `storybook.requires`, convert remaining `storiesOf` stories to CSF during the `6.5.x -> 7.6.x` upgrade, and stop after a single version hop instead of jumping multiple major versions at once.
+---
+
+# React Native Storybook Upgrades
+
+Upgrade one supported version step at a time. Do not jump from an older major directly to the latest release in a single pass.
+
+## Rules
+
+- Detect the project's package manager first and use it consistently.
+- Detect the currently installed Storybook version from `package.json`, lockfiles, and config files before editing anything.
+- Apply exactly one migration step per run. If a project is multiple versions behind, complete the next hop, verify it, and then report the next required hop.
+- During the `6.5.x -> 7.6.x` step, convert any remaining `storiesOf` stories to CSF instead of preserving compatibility mode.
+- Preserve the project's existing app structure. Only make the migration changes required for the current step.
+
+## Version Detection
+
+Look at these signals together:
+
+- `package.json` versions for `@storybook/react-native`, `storybook`, `@storybook/react`, and `@storybook/addon-ondevice-*`
+- Whether the config folder is `.storybook/` or `.rnstorybook/`
+- Metro config imports such as `metro/withStorybook`, `metro/withStorybookConfig`, or default-vs-named `withStorybook`
+- Story format usage: CSF vs `storiesOf`
+- Generated file names such as `storybook.requires.js` vs `storybook.requires.ts`
+
+If the version is ambiguous, stop and clarify the current installed version instead of guessing.
+
+## Migration Selection
+
+Use exactly one reference file:
+
+1. `9.x -> 10.x`: [references/from-9-to-10.md](references/from-9-to-10.md)
+2. `8.x -> 9.x`: [references/from-8-to-9.md](references/from-8-to-9.md)
+3. `7.6.x -> 8.3.x`: [references/from-7-6-to-8-3.md](references/from-7-6-to-8-3.md)
+4. `6.5.x -> 7.6.x`: [references/from-6-5-to-7-6.md](references/from-6-5-to-7-6.md)
+5. `5.3.x -> 6.5.x`: [references/from-5-3-to-6-5.md](references/from-5-3-to-6-5.md)
+
+## Workflow
+
+1. Confirm the current Storybook version and whether the repo uses Expo, Expo Router, React Native CLI, or Re.Pack.
+2. Pick the next migration step only. Never bundle multiple major upgrades together.
+3. Apply the dependency, config, and source-file changes from the matching reference.
+4. Regenerate `storybook.requires` or restart Metro when that step requires it.
+5. Run the smallest useful verification available for the repo, such as the generation script, tests, lint, or the local Storybook app launch path.
+6. If the repo still is not on the user's target version, stop with a clear note describing the next required migration step.
+
+## Output Expectations
+
+When you finish a migration step, report:
+
+- The version hop that was completed
+- The files and config surfaces that changed
+- The verification you ran, or what you could not run
+- The next required migration hop, if the project is still behind

--- a/skills/upgrading-react-native-storybook/references/from-5-3-to-6-5.md
+++ b/skills/upgrading-react-native-storybook/references/from-5-3-to-6-5.md
@@ -1,0 +1,170 @@
+# From 5.3.x to 6.5.x
+
+Use this only when the project is still on Storybook React Native `5.3.x`.
+
+## Main Changes
+
+- Add the new core dependencies used by the 6.5 architecture
+- Move to a generated `storybook.requires.js` flow
+- Introduce `.storybook/main.js` and `.storybook/preview.js`
+- Update Metro to prefer `sbmodern`
+
+This is the biggest structural migration step. Keep it isolated from later upgrades.
+
+## Dependencies
+
+Add the new base dependencies:
+
+- `@storybook/react-native`
+- `@storybook/core/common`
+- `@react-native-async-storage/async-storage`
+- `react-native-safe-area-context`
+- `react-dom`
+
+Add addon dependencies as needed:
+
+- controls: `@storybook/addon-ondevice-controls`, `@storybook/addons`, `@storybook/addon-controls`, `@react-native-community/datetimepicker`, `@react-native-community/slider`
+- actions: `@storybook/addon-ondevice-actions`, `@storybook/addon-actions`
+
+Example `package.json` shape after the upgrade:
+
+```json
+{
+  "devDependencies": {
+    "@storybook/react-native": "^6.5.16",
+    "@storybook/core/common": "^6.5.16",
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "react-native-safe-area-context": "^4.10.5",
+    "react-dom": "^18.2.0",
+    "@storybook/addon-ondevice-controls": "^6.5.16",
+    "@storybook/addons": "^6.5.16",
+    "@storybook/addon-controls": "^6.5.16",
+    "@storybook/addon-ondevice-actions": "^6.5.16",
+    "@storybook/addon-actions": "^6.5.16"
+  }
+}
+```
+
+Install commands vary by package manager. Example commands:
+
+```sh
+npm install --save-dev @storybook/react-native @storybook/core/common @react-native-async-storage/async-storage react-native-safe-area-context react-dom
+npm install --save-dev @storybook/addon-ondevice-controls @storybook/addons @storybook/addon-controls @react-native-community/datetimepicker @react-native-community/slider
+npm install --save-dev @storybook/addon-ondevice-actions @storybook/addon-actions
+```
+
+## Config Folder
+
+Rename the Storybook folder to `.storybook` if it is not already named that.
+
+## `.storybook/index.js`
+
+Reduce the entry file to the generated-import pattern:
+
+```js
+import { getStorybookUI } from '@storybook/react-native';
+import './storybook.requires';
+
+const StorybookUIRoot = getStorybookUI({});
+
+export default StorybookUIRoot;
+```
+
+Remove old manual `configure(...)`, direct story imports, and direct addon imports.
+
+## `main.js` and `preview.js`
+
+Create `.storybook/main.js` with the repo's story globs and on-device addons, then move global decorators and parameters into `.storybook/preview.js`.
+
+This step is where the Storybook config becomes file-driven instead of hard-coded in `index.js`.
+
+Example `.storybook/main.js`:
+
+```js
+module.exports = {
+  stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],
+  addons: [
+    '@storybook/addon-ondevice-controls',
+    '@storybook/addon-ondevice-actions',
+    '@storybook/addon-ondevice-backgrounds',
+  ],
+};
+```
+
+Example `.storybook/preview.js`:
+
+```jsx
+import { View } from 'react-native';
+
+export const decorators = [
+  (StoryFn) => (
+    <View style={{ flex: 1, padding: 8 }}>
+      <StoryFn />
+    </View>
+  ),
+];
+
+export const parameters = {
+  layout: 'fullscreen',
+};
+```
+
+## Scripts
+
+Add package scripts for the generated import flow:
+
+- `storybook-generate`: `sb-rn-get-stories`
+- `storybook-watch`: `sb-rn-watcher`
+
+Use the repo's existing package manager.
+
+Example `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "storybook-generate": "sb-rn-get-stories",
+    "storybook-watch": "sb-rn-watcher"
+  }
+}
+```
+
+## Metro
+
+Update Metro to prefer the `sbmodern` entrypoint:
+
+- Expo: prepend `sbmodern` to `resolver.resolverMainFields`
+- React Native CLI: set `resolverMainFields` to start with `sbmodern`
+
+Expo example:
+
+```js
+const { getDefaultConfig } = require('expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+defaultConfig.resolver.resolverMainFields.unshift('sbmodern');
+
+module.exports = defaultConfig;
+```
+
+React Native CLI example:
+
+```js
+module.exports = {
+  resolver: {
+    resolverMainFields: ['sbmodern', 'react-native', 'browser', 'main'],
+  },
+};
+```
+
+## Stories
+
+`storiesOf` can still exist after this step, but the required conversion to CSF should happen in the later `6.5.x -> 7.6.x` migration.
+
+## Verify
+
+- `storybook.requires.js` generates successfully
+- `index.js` only bootstraps Storybook instead of importing stories directly
+- `main.js` and `preview.js` exist and match the repo's story locations
+- Metro resolves Storybook packages through `sbmodern`

--- a/skills/upgrading-react-native-storybook/references/from-6-5-to-7-6.md
+++ b/skills/upgrading-react-native-storybook/references/from-6-5-to-7-6.md
@@ -1,0 +1,243 @@
+# From 6.5.x to 7.6.x
+
+Use this only when the project is on `6.5.x`.
+
+## Main Changes
+
+- Upgrade Storybook packages to `7.6.10` or newer within `7.x`
+- Regenerate `storybook.requires.ts`
+- Move `.storybook/index.js` to the new `view.getStorybookUI(...)` pattern
+- Update Metro for `unstable_allowRequireContext`
+- Move types to `@storybook/react`
+- Convert all remaining `storiesOf` stories to CSF
+
+## Dependencies
+
+Upgrade these packages together:
+
+- `@storybook/react-native`
+- `@storybook/addon-ondevice-actions`
+- `@storybook/addon-ondevice-backgrounds`
+- `@storybook/addon-ondevice-controls`
+- `@storybook/addon-ondevice-notes`
+
+This step also expects `@react-native-async-storage/async-storage` for the new storage option if the project does not already have it.
+
+Remove legacy dependencies and imports that only exist to support `storiesOf` and knobs once the stories are converted.
+
+Example dependency versions after the upgrade:
+
+```json
+{
+  "devDependencies": {
+    "@storybook/react-native": "^7.6.10",
+    "@storybook/addon-ondevice-actions": "^7.6.10",
+    "@storybook/addon-ondevice-backgrounds": "^7.6.10",
+    "@storybook/addon-ondevice-controls": "^7.6.10",
+    "@storybook/addon-ondevice-notes": "^7.6.10"
+  }
+}
+```
+
+## Generated Requires
+
+Regenerate Storybook imports so the project uses `storybook.requires.ts` instead of `storybook.requires.js`.
+
+Example command:
+
+```sh
+yarn storybook-generate
+```
+
+After regeneration, `.storybook/storybook.requires.ts` should exist and replace the old `.js` file.
+
+## `.storybook/index.*`
+
+Move the Storybook entry to the v7 API:
+
+```tsx
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { view } from './storybook.requires';
+
+const StorybookUIRoot = view.getStorybookUI({
+  storage: {
+    getItem: AsyncStorage.getItem,
+    setItem: AsyncStorage.setItem,
+  },
+});
+
+export default StorybookUIRoot;
+```
+
+Renaming the file to `.storybook/index.tsx` is fine if the repo already uses TypeScript.
+
+## Metro
+
+Enable dynamic imports with `unstable_allowRequireContext`.
+
+Also:
+
+- add `generate(...)` from `@storybook/react-native/scripts/generate` if the repo wants Metro startup to regenerate Storybook imports
+- add `mjs` to `resolver.sourceExts`
+- remove old `sbmodern` resolver changes if they still exist
+
+For Expo, generate a Metro config if the repo does not have one yet.
+
+Expo example:
+
+```js
+const path = require('path');
+const { getDefaultConfig } = require('expo/metro-config');
+const { generate } = require('@storybook/react-native/scripts/generate');
+
+generate({
+  configPath: path.resolve(__dirname, './.storybook'),
+});
+
+const config = getDefaultConfig(__dirname);
+
+config.transformer.unstable_allowRequireContext = true;
+config.resolver.sourceExts.push('mjs');
+
+module.exports = config;
+```
+
+React Native CLI example:
+
+```js
+const path = require('path');
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const { generate } = require('@storybook/react-native/scripts/generate');
+
+generate({
+  configPath: path.resolve(__dirname, './.storybook'),
+});
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+const config = {
+  transformer: {
+    unstable_allowRequireContext: true,
+  },
+  resolver: {
+    sourceExts: [...defaultConfig.resolver.sourceExts, 'mjs'],
+  },
+};
+
+module.exports = mergeConfig(defaultConfig, config);
+```
+
+## Types
+
+Story types move from `@storybook/react-native` to `@storybook/react` in this step.
+
+Typical updates:
+
+- `Meta` and `StoryObj` imports should come from `@storybook/react`
+- `.storybook/main.ts` can use `StorybookConfig` from `@storybook/react-native`
+- `.storybook/preview.tsx` can use `Preview` from `@storybook/react`
+
+Story file example:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta = {
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    text: 'Press me!',
+  },
+};
+```
+
+`.storybook/main.ts` example:
+
+```ts
+import type { StorybookConfig } from '@storybook/react-native';
+
+const main: StorybookConfig = {
+  stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],
+  addons: [
+    '@storybook/addon-ondevice-notes',
+    '@storybook/addon-ondevice-controls',
+    '@storybook/addon-ondevice-backgrounds',
+    '@storybook/addon-ondevice-actions',
+  ],
+};
+
+export default main;
+```
+
+`.storybook/preview.tsx` example:
+
+```tsx
+import type { Preview } from '@storybook/react';
+
+const preview: Preview = {
+  decorators: [],
+  parameters: {},
+};
+
+export default preview;
+```
+
+## Stories
+
+If the repo still uses `storiesOf`, convert all of those stories to CSF as part of this migration step. Do not keep a compatibility mode.
+
+Use the Storybook codemod as a starting point when it helps:
+
+```sh
+npx storybook@next migrate storiesof-to-csf --glob="src/**/*.stories.tsx"
+```
+
+Before doing the manual cleanup, read [storiesof-to-csf-examples.md](storiesof-to-csf-examples.md). That companion reference contains the full before/after examples for each part of the checklist below:
+
+- converting `storiesOf(...).add(...)` chains to CSF exports
+- moving shared decorators and parameters into `meta`
+- replacing knobs-era code with `args` and `argTypes`
+- converting stateful interactive stories to CSF `render`
+- removing legacy imports such as `@storybook/react-native/V6`, `@storybook/addon-knobs`, and `@storybook/addon-ondevice-knobs`
+
+Then finish the conversion manually:
+
+- replace `storiesOf(...).add(...)` chains with a default export plus named story exports
+- move shared decorators and parameters to the default export or `preview`
+- replace knobs-era patterns with args and argTypes where appropriate
+- remove imports from deprecated runtime paths such as `@storybook/react-native/V6`
+- remove `@storybook/addon-ondevice-knobs` usage once no converted story depends on it
+
+## Doctools
+
+Remove any manual doctools bootstrap that was previously added in `preview.js` or related setup. Auto args wiring is now handled for you.
+
+Example removal:
+
+```diff
+-import { extractArgTypes } from '@storybook/react/dist/modern/client/docs/extractArgTypes';
+-import { addArgTypesEnhancer, addParameters } from '@storybook/react-native';
+-import { enhanceArgTypes } from '@storybook/core/docs-tools';
+-
+-addArgTypesEnhancer(enhanceArgTypes);
+-addParameters({
+-  docs: {
+-    extractArgTypes,
+-  },
+-});
+```
+
+## Verify
+
+- `storybook.requires.ts` is generated
+- `.storybook/index.*` uses `view.getStorybookUI`
+- Metro has `unstable_allowRequireContext`
+- Story files import types from `@storybook/react`, not `@storybook/react-native`
+- No remaining `storiesOf(`, `@storybook/react-native/V6`, `@storybook/addon-knobs`, or `@storybook/addon-ondevice-knobs` imports remain in the upgraded codebase

--- a/skills/upgrading-react-native-storybook/references/from-7-6-to-8-3.md
+++ b/skills/upgrading-react-native-storybook/references/from-7-6-to-8-3.md
@@ -1,0 +1,100 @@
+# From 7.6.x to 8.3.x
+
+Use this only when the project is already on Storybook React Native `7.6.x`.
+
+## Main Changes
+
+- Upgrade all Storybook packages to `8.3.5` or newer within `8.x`
+- Add the new UI runtime dependencies
+- Regenerate `.storybook/storybook.requires.ts`
+- Wrap Metro with `@storybook/react-native/metro/withStorybook`
+
+Do not rename `.storybook/` yet. That happens in the `8 -> 9` step.
+
+## Dependencies
+
+Update Storybook packages together:
+
+- `@storybook/react-native`
+- `@storybook/react`
+- `@storybook/addon-ondevice-actions`
+- `@storybook/addon-ondevice-backgrounds`
+- `@storybook/addon-ondevice-controls`
+- `@storybook/addon-ondevice-notes`
+
+Add the new native UI dependencies required by this release:
+
+- `react-native-reanimated`
+- `react-native-gesture-handler`
+- `@gorhom/bottom-sheet`
+- `react-native-svg`
+
+For Expo projects, install those native packages with `expo install` so versions match the Expo SDK.
+
+Example `package.json` shape after the upgrade:
+
+```json
+{
+  "devDependencies": {
+    "@storybook/react-native": "^8.3.5",
+    "@storybook/react": "^8.3.5",
+    "@storybook/addon-ondevice-controls": "^8.3.5",
+    "@storybook/addon-ondevice-actions": "^8.3.5",
+    "@storybook/addon-ondevice-backgrounds": "^8.3.5",
+    "@storybook/addon-ondevice-notes": "^8.3.5"
+  }
+}
+```
+
+Example install commands:
+
+```sh
+npx expo install react-native-reanimated react-native-gesture-handler @gorhom/bottom-sheet react-native-svg
+npm install --save-dev @storybook/react-native@^8.3.5 @storybook/react@^8.3.5 @storybook/addon-ondevice-controls@^8.3.5 @storybook/addon-ondevice-actions@^8.3.5 @storybook/addon-ondevice-backgrounds@^8.3.5 @storybook/addon-ondevice-notes@^8.3.5
+```
+
+## Generated Requires
+
+Regenerate `.storybook/storybook.requires.ts`.
+
+The generated file should now include an `updateView` export.
+
+Example command:
+
+```sh
+yarn storybook-generate
+```
+
+## Metro
+
+Wrap the Metro config with `withStorybook`:
+
+```js
+const path = require('path');
+const withStorybook = require('@storybook/react-native/metro/withStorybook');
+
+module.exports = withStorybook(config, {
+  enabled: true,
+  configPath: path.resolve(__dirname, './.storybook'),
+});
+```
+
+Keep the existing `.storybook` config path during this step.
+
+If the repo already has a Metro config, the change is usually from exporting `config` directly to wrapping it:
+
+```diff
+-module.exports = config;
++const withStorybook = require('@storybook/react-native/metro/withStorybook');
++
++module.exports = withStorybook(config, {
++  enabled: true,
++  configPath: path.resolve(__dirname, './.storybook'),
++});
+```
+
+## Verify
+
+- The new native dependencies are installed and compatible with the repo's Expo or React Native version
+- `storybook.requires.ts` was regenerated successfully
+- Metro boots with the `withStorybook` wrapper

--- a/skills/upgrading-react-native-storybook/references/from-8-to-9.md
+++ b/skills/upgrading-react-native-storybook/references/from-8-to-9.md
@@ -1,0 +1,87 @@
+# From 8.x to 9.x
+
+Use this only when the project is already on Storybook React Native `8.x`.
+
+## Main Changes
+
+- Upgrade Storybook packages to `9.x`
+- Rename the config folder from `.storybook/` to `.rnstorybook/`
+- Regenerate `storybook.requires.ts` in the new folder
+
+Do not also apply the `9 -> 10` changes during this step.
+
+## Dependencies
+
+Update Storybook dependencies to `9.x`, keeping the package family aligned:
+
+- `storybook`
+- `@storybook/react-native`
+- `@storybook/addon-ondevice-actions`
+- `@storybook/addon-ondevice-backgrounds`
+- `@storybook/addon-ondevice-controls`
+- `@storybook/addon-ondevice-notes`
+
+If the repo also uses `@storybook/react`, align that package to the same major.
+
+Example `package.json` shape after the upgrade:
+
+```json
+{
+  "devDependencies": {
+    "storybook": "^9.1.4",
+    "@storybook/react": "^9.1.4",
+    "@storybook/react-native": "^9.1.4",
+    "@storybook/addon-ondevice-actions": "^9.1.4",
+    "@storybook/addon-ondevice-backgrounds": "^9.1.4",
+    "@storybook/addon-ondevice-controls": "^9.1.4",
+    "@storybook/addon-ondevice-notes": "^9.1.4"
+  }
+}
+```
+
+## Folder Rename
+
+Rename the React Native Storybook config folder:
+
+- from `.storybook/`
+- to `.rnstorybook/`
+
+Then update every path that points at it, including:
+
+- app entry imports
+- Metro config `configPath`
+- generation scripts
+- docs or helper scripts that reference the config directory
+
+Example path updates:
+
+```diff
+-import StorybookUI from './.storybook';
++import StorybookUI from './.rnstorybook';
+```
+
+```diff
+-configPath: path.resolve(__dirname, './.storybook'),
++configPath: path.resolve(__dirname, './.rnstorybook'),
+```
+
+```diff
+-"storybook-generate": "sb-rn-get-stories -c ./.storybook"
++"storybook-generate": "sb-rn-get-stories -c ./.rnstorybook"
+```
+
+## Regenerate
+
+Regenerate `.rnstorybook/storybook.requires.ts` after the rename.
+
+Example command:
+
+```sh
+yarn storybook-generate
+```
+
+## Verify
+
+- No remaining references to the old `.storybook/` path for React Native Storybook
+- The generated requires file now lives under `.rnstorybook/`
+- Storybook still boots after the rename

--- a/skills/upgrading-react-native-storybook/references/from-9-to-10.md
+++ b/skills/upgrading-react-native-storybook/references/from-9-to-10.md
@@ -1,0 +1,169 @@
+# From 9.x to 10.x
+
+Use this only when the project is already on Storybook React Native `9.x`.
+
+## Main Changes
+
+- Upgrade all Storybook packages to `10.x`.
+- Move Metro usage to the v10 `withStorybook` API.
+- Simplify app entrypoints so Storybook can be imported at the top level.
+- Regenerate `.rnstorybook/storybook.requires.ts`.
+
+## Dependencies
+
+Update the Storybook packages together:
+
+- `storybook`
+- `@storybook/react`
+- `@storybook/react-native`
+- `@storybook/addon-ondevice-actions`
+- `@storybook/addon-ondevice-backgrounds`
+- `@storybook/addon-ondevice-controls`
+- `@storybook/addon-ondevice-notes`
+
+Keep versions aligned on `10.x`.
+
+Example `package.json` shape after the upgrade:
+
+```json
+{
+  "devDependencies": {
+    "storybook": "^10",
+    "@storybook/react": "^10",
+    "@storybook/react-native": "^10",
+    "@storybook/addon-ondevice-controls": "^10",
+    "@storybook/addon-ondevice-actions": "^10",
+    "@storybook/addon-ondevice-backgrounds": "^10",
+    "@storybook/addon-ondevice-notes": "^10"
+  }
+}
+```
+
+## Metro
+
+In v10:
+
+- `withStorybook` must be imported as a named export from `@storybook/react-native/metro/withStorybook`
+- `withStorybookConfig` is no longer used
+- `onDisabledRemoveStorybook` is removed
+- `enabled: false` automatically strips Storybook from the bundle
+- `configPath` is optional when the config folder is the default `./.rnstorybook`
+
+Update old patterns like these:
+
+- `const withStorybook = require(...)`
+- `const { withStorybookConfig } = require(...)`
+- any config using `onDisabledRemoveStorybook`
+
+to the v10 shape:
+
+```js
+const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
+
+module.exports = withStorybook(defaultConfig, {
+  enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
+});
+```
+
+Only include `configPath` when the project uses a non-default Storybook config folder.
+
+Example with a custom folder:
+
+```js
+const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
+
+module.exports = withStorybook(defaultConfig, {
+  enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
+  configPath: path.resolve(__dirname, './storybook-native'),
+});
+```
+
+Full before/after example:
+
+```js
+// Before
+const withStorybook = require('@storybook/react-native/metro/withStorybook');
+
+module.exports = withStorybook(defaultConfig, {
+  enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
+  onDisabledRemoveStorybook: true,
+  configPath: path.resolve(__dirname, './storybook-native'),
+});
+```
+
+```js
+// After
+const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
+
+module.exports = withStorybook(defaultConfig, {
+  enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
+  configPath: path.resolve(__dirname, './storybook-native'),
+});
+```
+
+If the project already uses the default `.rnstorybook` folder, the after version should omit `configPath` entirely.
+
+## App Entry
+
+Remove defensive conditional `require()` patterns that existed only to avoid bundling Storybook.
+
+In v10, top-level imports are safe again:
+
+```tsx
+import StorybookUI from './.rnstorybook';
+```
+
+Before/after app entry example:
+
+```tsx
+// Before
+let AppEntryPoint = App;
+
+if (process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true') {
+  AppEntryPoint = require('./.rnstorybook').default;
+}
+
+export default AppEntryPoint;
+```
+
+```tsx
+// After
+import StorybookUI from './.rnstorybook';
+import { Text, View } from 'react-native';
+
+const isStorybook = process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true';
+
+const AppComponent = () => (
+  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <Text>Hello World</Text>
+  </View>
+);
+
+export default function App() {
+  return isStorybook ? <StorybookUI /> : <AppComponent />;
+}
+```
+
+For Expo Router, a dedicated route can just re-export the Storybook entry:
+
+```tsx
+export { default } from '../.rnstorybook';
+```
+
+## Regenerate
+
+Regenerate `.rnstorybook/storybook.requires.ts` with the project's package manager, or restart Metro if the repo already generates it during Metro startup.
+
+Example commands:
+
+```sh
+yarn storybook-generate
+yarn start --reset-cache
+```
+
+## Verify
+
+- Metro config still resolves `./.rnstorybook`
+- Storybook launches when enabled
+- Storybook code is removed when disabled
+- No stale `withStorybookConfig` or `onDisabledRemoveStorybook` usage remains

--- a/skills/upgrading-react-native-storybook/references/from-9-to-10.md
+++ b/skills/upgrading-react-native-storybook/references/from-9-to-10.md
@@ -67,14 +67,14 @@ module.exports = withStorybook(defaultConfig, {
 
 Only include `configPath` when the project uses a non-default Storybook config folder.
 
-Example with a custom folder:
+If you keep the option for clarity while still using the default folder, it should still point at `.rnstorybook`, but it is redundant:
 
 ```js
 const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
 
 module.exports = withStorybook(defaultConfig, {
   enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
-  configPath: path.resolve(__dirname, './storybook-native'),
+  configPath: path.resolve(__dirname, './.rnstorybook'),
 });
 ```
 
@@ -87,21 +87,30 @@ const withStorybook = require('@storybook/react-native/metro/withStorybook');
 module.exports = withStorybook(defaultConfig, {
   enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
   onDisabledRemoveStorybook: true,
-  configPath: path.resolve(__dirname, './storybook-native'),
+  configPath: path.resolve(__dirname, './.rnstorybook'),
 });
 ```
 
 ```js
-// After
+// After (preferred)
 const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
 
 module.exports = withStorybook(defaultConfig, {
   enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
-  configPath: path.resolve(__dirname, './storybook-native'),
 });
 ```
 
-If the project already uses the default `.rnstorybook` folder, the after version should omit `configPath` entirely.
+```js
+// After (equivalent but redundant when using the default folder)
+const { withStorybook } = require('@storybook/react-native/metro/withStorybook');
+
+module.exports = withStorybook(defaultConfig, {
+  enabled: process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true',
+  configPath: path.resolve(__dirname, './.rnstorybook'),
+});
+```
+
+If the project already uses the default `.rnstorybook` folder, prefer omitting `configPath` entirely.
 
 ## App Entry
 

--- a/skills/upgrading-react-native-storybook/references/storiesof-to-csf-examples.md
+++ b/skills/upgrading-react-native-storybook/references/storiesof-to-csf-examples.md
@@ -1,0 +1,294 @@
+# `storiesOf` to CSF Examples
+
+Use these examples during the `6.5.x -> 7.6.x` migration when converting legacy `storiesOf` files to CSF.
+This is the detailed companion reference for the manual conversion checklist in [from-6-5-to-7-6.md](from-6-5-to-7-6.md).
+
+## Contents
+
+- Basic `storiesOf` chain to CSF
+- Move decorators and parameters to `meta`
+- Replace knobs with `args` and `argTypes`
+- Convert inline stateful stories to `render`
+- Remove legacy runtime and knobs imports
+
+## Basic `storiesOf` Chain to CSF
+
+Before:
+
+```tsx
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { Button } from './Button';
+
+storiesOf('Button', module)
+  .add('primary', () => <Button label="Primary" variant="primary" />)
+  .add('secondary', () => <Button label="Secondary" variant="secondary" />);
+```
+
+After:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta = {
+  title: 'Button',
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    label: 'Primary',
+    variant: 'primary',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: 'Secondary',
+    variant: 'secondary',
+  },
+};
+```
+
+## Move Decorators and Parameters to `meta`
+
+Before:
+
+```tsx
+import React from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { Badge } from './Badge';
+
+storiesOf('Badge', module)
+  .addDecorator((Story) => (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+      <Story />
+    </View>
+  ))
+  .addParameters({
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#111' }],
+    },
+  })
+  .add('default', () => <Badge label="New" />)
+  .add('success', () => <Badge label="Saved" tone="success" />);
+```
+
+After:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { View } from 'react-native';
+import { Badge } from './Badge';
+
+const meta = {
+  title: 'Badge',
+  component: Badge,
+  decorators: [
+    (Story) => (
+      <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+        <Story />
+      </View>
+    ),
+  ],
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#111' }],
+    },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: 'New',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    label: 'Saved',
+    tone: 'success',
+  },
+};
+```
+
+## Replace Knobs With `args` and `argTypes`
+
+Before:
+
+```tsx
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { text, boolean, select } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-ondevice-knobs';
+import { Chip } from './Chip';
+
+storiesOf('Chip', module)
+  .addDecorator(withKnobs)
+  .add('playground', () => (
+    <Chip
+      label={text('label', 'Example')}
+      selected={boolean('selected', false)}
+      tone={select('tone', ['neutral', 'info', 'danger'], 'neutral')}
+    />
+  ));
+```
+
+After:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Chip } from './Chip';
+
+const meta = {
+  title: 'Chip',
+  component: Chip,
+  argTypes: {
+    tone: {
+      options: ['neutral', 'info', 'danger'],
+      control: { type: 'select' },
+    },
+    selected: {
+      control: { type: 'boolean' },
+    },
+    label: {
+      control: { type: 'text' },
+    },
+  },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    label: 'Example',
+    selected: false,
+    tone: 'neutral',
+  },
+};
+```
+
+Migration notes:
+
+- remove `withKnobs`
+- remove `@storybook/addon-knobs` and `@storybook/addon-ondevice-knobs`
+- move default values from knob calls into `args`
+- move knob option lists into `argTypes`
+
+## Convert Callbacks and Inline Stateful Stories
+
+Before:
+
+```tsx
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { action } from '@storybook/addon-actions';
+import { Counter } from './Counter';
+
+storiesOf('Counter', module).add('interactive', () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <Counter
+      count={count}
+      onIncrement={() => {
+        action('increment pressed')();
+        setCount((current) => current + 1);
+      }}
+    />
+  );
+});
+```
+
+After:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { useState } from 'react';
+import { Counter } from './Counter';
+
+const meta = {
+  title: 'Counter',
+  component: Counter,
+  args: {
+    onIncrement: fn(),
+  },
+} satisfies Meta<typeof Counter>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Interactive: Story = {
+  render: function InteractiveRender(args) {
+    const [count, setCount] = useState(0);
+
+    return (
+      <Counter
+        {...args}
+        count={count}
+        onIncrement={() => {
+          args.onIncrement();
+          setCount((current) => current + 1);
+        }}
+      />
+    );
+  },
+};
+```
+
+Migration notes:
+
+- use a named `render` function when hooks are needed
+- prefer `fn()` for callback args instead of `action(...)` in story bodies
+- keep local state in `render`, not in a top-level story object
+
+## Remove Legacy Runtime and Knobs Imports
+
+Before:
+
+```tsx
+import { storiesOf } from '@storybook/react-native/V6';
+import { text, boolean } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-ondevice-knobs';
+```
+
+After:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+```
+
+If the file previously depended on a knobs decorator, remove it after converting the story to args-based CSF:
+
+```diff
+-storiesOf('Example', module).addDecorator(withKnobs);
+```
+
+The replacement should live in the CSF `meta` object with `args` and `argTypes`, not in a decorator import.
+
+## Checklist
+
+After converting a file:
+
+- remove `storiesOf` imports
+- remove `module` usage
+- remove knobs and legacy decorator imports
+- export a default `meta` object
+- add a `StoryObj<typeof meta>` alias
+- convert each `.add(...)` call into a named story export


### PR DESCRIPTION
## Summary
- add a new `upgrading-react-native-storybook` skill with incremental migration references from 5.3.x through 10.x
- add a dedicated `storiesOf` to CSF conversion reference and make the 6.5.x -> 7.6.x guide point to it explicitly
- update setup and docs references so the new skill is discoverable and v10 `configPath` guidance reflects `.rnstorybook` as the default

## Testing
- git diff --check
