### PR TITLE
fix: align metro env module typings with Expo

### DIFF
--- a/.changeset/big-symbols-see.md
+++ b/.changeset/big-symbols-see.md
@@ -1,0 +1,5 @@
+---
+'@storybook/react-native': patch
+---
+
+fix types for metro require

--- a/packages/react-native/metro-env.d.ts
+++ b/packages/react-native/metro-env.d.ts
@@ -65,4 +65,5 @@ declare namespace NodeJS {
   }
 }
 
+// eslint-disable-next-line no-var -- ambient global declaration must merge with Node's `var module`
 declare var module: NodeJS.Module;

--- a/packages/react-native/metro-env.d.ts
+++ b/packages/react-native/metro-env.d.ts
@@ -57,13 +57,12 @@ declare namespace __MetroModuleApi {
   }
 }
 
-declare const module: NodeModule;
-
 declare namespace NodeJS {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Intentional declaration merging to extend NodeJS.Require
   interface Require extends __MetroModuleApi.RequireFunction {}
+  interface Module {
+    hot?: __MetroModuleApi.Hot;
+  }
 }
 
-interface NodeModule {
-  hot?: __MetroModuleApi.Hot;
-}
+declare var module: NodeJS.Module;


### PR DESCRIPTION
## Summary
- augment `NodeJS.Module` instead of the deprecated `NodeModule` alias in `metro-env.d.ts`
- declare the global `module` as `NodeJS.Module` so it merges cleanly with modern `@types/node`
- keep `require.context` and `module.hot` available for generated `storybook.requires.ts` files in Expo projects

## Root cause
`storybook.requires.ts` references `module?.hot?.accept?.()` under the Metro env types. In modern Expo/TypeScript setups, the global `module` comes from `@types/node` as `NodeJS.Module`. Our env file was augmenting `NodeModule` instead, so the `hot` property was added to the wrong interface.

## Verification
- `pnpm build`
- `pnpm --filter expo-example check`
- `pnpm --filter @storybook/react-native check:types`