### PR TITLE
fix: update default value for enableWebsockets in View component

### DIFF
--- a/.changeset/slick-ants-double.md
+++ b/.changeset/slick-ants-double.md
@@ -1,0 +1,5 @@
+---
+'@storybook/react-native': patch
+---
+
+auto-detect websocket enabling

--- a/packages/react-native/src/View.tsx
+++ b/packages/react-native/src/View.tsx
@@ -264,7 +264,7 @@ export class View {
 
   getStorybookUI = (params: Partial<Params> = {}) => {
     const {
-      enableWebsockets = false,
+      enableWebsockets = !!globalThis.STORYBOOK_WEBSOCKET,
       CustomUIComponent,
       hasStoryWrapper: storyViewWrapper = true,
     } = params;

--- a/packages/react-native/src/View.tsx
+++ b/packages/react-native/src/View.tsx
@@ -94,7 +94,7 @@ export type Params = {
   hasStoryWrapper?: boolean;
   /**
    * Enable websockets for the storybook server to remotely control the storybook
-   * default: false
+   * default: automatically enabled when a websocket config is injected via storybook.requires (i.e. when STORYBOOK_WS_HOST is set), otherwise false
    */
   enableWebsockets?: boolean;
   query?: string;


### PR DESCRIPTION
## What I did

I made the `enableWebsockets` option auto-enable, based on the generated config runtime.

## How to test

Provide environment variables for websockets, but don't explicitly setup `enableWebsockets` inside of `.rnstorybook/index.tsx`.

The expected outcome is that the storybook connects to the given websocket address.