### PR TITLE
Fix vulnerable transitive dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   postcss: 8.5.14
   react-docgen-typescript: 2.2.2
   serialize-javascript: 7.0.5
+  shell-quote: 1.8.4
   svgo: 3.3.3
   webpack-dev-server: ^5.2.2
   zod-validation-error: ^4.0.0
@@ -8468,9 +8469,9 @@ packages:
       '@types/express':
         optional: true
 
-  http-proxy-middleware@3.0.5:
-    resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  http-proxy-middleware@3.0.7:
+    resolution: {integrity: sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==}
+    engines: {node: ^14.18.0 || ^16.10.0 || >=18.0.0}
 
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -11502,8 +11503,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   sherif-darwin-arm64@1.11.1:
@@ -12280,8 +12281,8 @@ packages:
   undici-types@7.21.0:
     resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -15102,7 +15103,7 @@ snapshots:
       fastify: 5.8.5
       fastify-favicon: 5.0.0
       fastify-plugin: 5.1.0
-      http-proxy-middleware: 3.0.5
+      http-proxy-middleware: 3.0.7
       launch-editor: 2.13.2
       open: 10.2.0
       pretty-format: 28.1.3
@@ -17236,7 +17237,7 @@ snapshots:
       abort-controller: 3.0.0
       debug: 4.4.3
       source-map-support: 0.5.21
-      undici: 6.25.0
+      undici: 6.27.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23545,7 +23546,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy-middleware@3.0.5:
+  http-proxy-middleware@3.0.7:
     dependencies:
       '@types/http-proxy': 1.17.17
       debug: 4.4.3
@@ -24461,7 +24462,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   leven@3.1.0: {}
 
@@ -26598,7 +26599,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
@@ -27538,7 +27539,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   sherif-darwin-arm64@1.11.1:
     optional: true
@@ -28361,7 +28362,7 @@ snapshots:
 
   undici-types@7.21.0: {}
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ overrides:
   postcss: 8.5.14
   react-docgen-typescript: 2.2.2
   serialize-javascript: 7.0.5
+  shell-quote: 1.8.4
   svgo: 3.3.3
   webpack-dev-server: ^5.2.2
   zod-validation-error: ^4.0.0


### PR DESCRIPTION
Issue:

Fixes Dependabot security alerts for vulnerable transitive dependencies in the pnpm lockfile:

- `shell-quote` (`GHSA-w7jw-789q-3m8p` / CVE-2026-9277)
- `undici` (`GHSA-vxpw-j846-p89q` / CVE-2026-12151)
- `http-proxy-middleware` (`GHSA-gcq2-9pq2-cxqm` / CVE-2026-55603)

## What I did

- Added a pnpm override for `shell-quote@1.8.4` because the affected parents resolve `shell-quote@1.8.3` directly.
- Updated `pnpm-lock.yaml` to resolve `undici@6.27.0` through the existing `@expo/server` semver range.
- Updated `pnpm-lock.yaml` to resolve `http-proxy-middleware@3.0.7` through the existing `@callstack/repack-dev-server` semver range.
- Left the Docusaurus `http-proxy-middleware@2.0.9` path unchanged because this alert only affects the 3.x and 4.x vulnerable ranges.

## How to test

Validated with:

- `pnpm install`
- `pnpm why shell-quote --recursive`
- `pnpm why undici --recursive`
- `pnpm why http-proxy-middleware --recursive`
- targeted `pnpm audit --json` parsing for the three GHSA IDs

This does not need a new example in `examples/expo-example`.
This does not need a documentation update.