### PR TITLE
fix: restore docgen auto argTypes (wrong @storybook/react entry point)

### DIFF
--- a/.changeset/fix-docgen-argtypes-entry-point.md
+++ b/.changeset/fix-docgen-argtypes-entry-point.md
@@ -1,0 +1,5 @@
+---
+"@storybook/react-native": patch
+---
+
+Fix docgen-based auto argTypes (controls) that were silently disabled. `preview.ts` imported `argTypesEnhancers` and `parameters.docs.extractArgTypes` from `@storybook/react/entry-preview-docs`, which does not export them, so both resolved to `undefined`. They are now imported from `@storybook/react/entry-preview-argtypes`, restoring auto-generated controls from component `__docgenInfo`.

--- a/packages/react-native/src/preview.test.ts
+++ b/packages/react-native/src/preview.test.ts
@@ -1,0 +1,20 @@
+import preview from './preview';
+
+// Regression test for the entry-point bug where `argTypesEnhancers` and
+// `parameters.docs.extractArgTypes` were imported from
+// `@storybook/react/entry-preview-docs` — which does not export them, so both
+// resolved to `undefined` and docgen-based auto argTypes were silently disabled.
+// They are exported from `@storybook/react/entry-preview-argtypes`.
+describe('preview docgen wiring', () => {
+  it('wires argTypesEnhancers from @storybook/react', () => {
+    expect(Array.isArray(preview.argTypesEnhancers)).toBe(true);
+    expect(preview.argTypesEnhancers?.length).toBeGreaterThan(0);
+    preview.argTypesEnhancers?.forEach((enhancer) => {
+      expect(typeof enhancer).toBe('function');
+    });
+  });
+
+  it('wires parameters.docs.extractArgTypes from @storybook/react', () => {
+    expect(typeof preview.parameters?.docs?.extractArgTypes).toBe('function');
+  });
+});

--- a/packages/react-native/src/preview.ts
+++ b/packages/react-native/src/preview.ts
@@ -1,8 +1,4 @@
 import { Platform } from 'react-native';
-// `argTypesEnhancers` and `parameters.docs.extractArgTypes` are exported from the
-// `entry-preview-argtypes` entry point, not `entry-preview-docs`. Importing them
-// from `entry-preview-docs` resolves to `undefined`, which silently disables
-// docgen-based auto argTypes (controls then only come from core value inference).
 import {
   parameters as reactParameters,
   argTypesEnhancers,

--- a/packages/react-native/src/preview.ts
+++ b/packages/react-native/src/preview.ts
@@ -1,8 +1,12 @@
 import { Platform } from 'react-native';
+// `argTypesEnhancers` and `parameters.docs.extractArgTypes` are exported from the
+// `entry-preview-argtypes` entry point, not `entry-preview-docs`. Importing them
+// from `entry-preview-docs` resolves to `undefined`, which silently disables
+// docgen-based auto argTypes (controls then only come from core value inference).
 import {
   parameters as reactParameters,
   argTypesEnhancers,
-} from '@storybook/react/entry-preview-docs';
+} from '@storybook/react/entry-preview-argtypes';
 import { type Preview } from '@storybook/react';
 
 // Workaround for Reanimated globals not being available on web.


### PR DESCRIPTION
## Summary

Auto-generated controls from a component's TypeScript props (docgen) were silently broken in on-device Storybook. Stories that relied on `__docgenInfo` (no hand-written `argTypes`) showed no controls — or, where core value-inference kicked in, every prop rendered as a plain **text** field (enums never became radios, booleans/colors were lost).

Root cause: `packages/react-native/src/preview.ts` imported `argTypesEnhancers` and `parameters.docs.extractArgTypes` from `@storybook/react/entry-preview-docs`, but those symbols are exported from **`@storybook/react/entry-preview-argtypes`**. The old import resolved to `undefined`, so the docgen `argTypesEnhancer` (`enhanceArgTypes`) never ran. Manual-`argTypes` stories kept working, which masked the regression.

```diff
-} from '@storybook/react/entry-preview-docs';
+} from '@storybook/react/entry-preview-argtypes';
```

## Why this is the right fix

- `entry-preview-docs` exports only `applyDecorators, decorators, parameters` (and `parameters.docs` only has `story`). `argTypesEnhancers` and `extractArgTypes` live in `entry-preview-argtypes`.
- This is **not** a canary/`experimentalDocgenServer` issue. The entry-point layout is identical in the stable release this repo targets (`@storybook/react@10.4.x`) and back through `9.x`; auto-docgen had been quietly broken on stable, independent of any canary.
- No back-compat fallback is needed: `entry-preview-argtypes` exists across RN's supported Storybook range (peer dep `>=10`; present since [`v10.0.0`](https://github.com/storybookjs/storybook/blob/v10.0.0/code/renderers/react/src/entry-preview-argtypes.ts)).

## Two red herrings ruled out during investigation

- **The docgen-server canary (storybookjs/storybook#35196)** gates all its behavior behind `global.FEATURES.experimentalDocgenServer`, which RN never enables — so it does not affect RN.
- **A debug `console.log(Component.__docgenInfo)` printing `undefined`** was a statement-ordering artifact: `babel-plugin-react-docgen-typescript` appends the `__docgenInfo` assignment to the bottom of the module, so a top-level log runs before it. Babel docgen was working the whole time.

## Test plan

- [x] Added a regression unit test (`packages/react-native/src/preview.test.ts`) asserting `preview.argTypesEnhancers` is a non-empty array of functions and `preview.parameters.docs.extractArgTypes` is a function. It fails against the old `entry-preview-docs` import (both `undefined`) and passes with the fix.
- [x] Manual end-to-end validation on **stable `@storybook/react@10.4.6`** (no canary): a component-only story produced full auto controls, including a docgen-only `size` **radio** (`small | medium | large`) — a value set that only exists in the TS union type, so it can only come from docgen.

## Changeset

Patch (`@storybook/react-native`), which bumps the fixed package group.

Here's a screenshot of the correct controls due to properly injected __docgenInfo:
<img width="537" height="1022" alt="Screenshot 2026-06-24 at 09 17 55" src="https://github.com/user-attachments/assets/e2c557bd-aa67-4343-a1dd-43797f3d41e8" />
This was taken form an isolated example, which had it's node_modules patched with the fix this PR contains.