### PR TITLE
fix: send the telemetry dev event and report framework metadata

### DIFF
--- a/.changeset/telemetry-report-framework-metadata.md
+++ b/.changeset/telemetry-report-framework-metadata.md
@@ -1,0 +1,12 @@
+---
+'@storybook/react-native': patch
+---
+
+Telemetry: actually send the `dev` event and report framework metadata
+
+React Native runs through Metro/Re.Pack rather than the Storybook core-server, so two things were missing from the `dev` telemetry event:
+
+- The telemetry module's enabled state was never resolved (that normally happens in the core-server), so the event was queued and never sent. `withStorybook` now calls `setTelemetryEnabled(true)` when telemetry is enabled, flushing the event.
+- The event was sent without a `configDir`, so `getStorybookMetadata` defaulted to `.storybook` and could not read React Native's `.rnstorybook` config, leaving `metadata.framework` empty. The resolved config path is now passed through.
+
+Applied to the Metro, Re.Pack, and shared `withStorybook` entry points.

--- a/packages/react-native/src/metro/withStorybook.test.ts
+++ b/packages/react-native/src/metro/withStorybook.test.ts
@@ -1,6 +1,8 @@
 import type { MetroConfig } from 'metro-config';
 import { createChannelServer } from './channelServer';
 import { generate } from '../../scripts/generate';
+import { optionalEnvToBoolean } from 'storybook/internal/common';
+import { telemetry } from 'storybook/internal/telemetry';
 
 jest.mock('./channelServer', () => ({
   createChannelServer: jest.fn(),
@@ -58,6 +60,20 @@ describe('withStorybook experimental_mcp', () => {
     );
     expect(generateArgs.host).toBeUndefined();
     expect(generateArgs.port).toBeUndefined();
+  });
+
+  test('reports telemetry with the resolved configDir so framework metadata is captured', () => {
+    (optionalEnvToBoolean as jest.Mock).mockReturnValue(false);
+
+    withStorybook(config, {
+      configPath: '/tmp/.rnstorybook',
+      enabled: true,
+    });
+    expect(telemetry).toHaveBeenCalledWith(
+      'dev',
+      {},
+      expect.objectContaining({ configDir: '/tmp/.rnstorybook' })
+    );
   });
 
   test('passes experimental_mcp to channel server when websockets are configured', () => {

--- a/packages/react-native/src/metro/withStorybook.test.ts
+++ b/packages/react-native/src/metro/withStorybook.test.ts
@@ -2,7 +2,7 @@ import type { MetroConfig } from 'metro-config';
 import { createChannelServer } from './channelServer';
 import { generate } from '../../scripts/generate';
 import { optionalEnvToBoolean } from 'storybook/internal/common';
-import { telemetry } from 'storybook/internal/telemetry';
+import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
 
 jest.mock('./channelServer', () => ({
   createChannelServer: jest.fn(),
@@ -18,6 +18,7 @@ jest.mock('storybook/internal/common', () => ({
 
 jest.mock('storybook/internal/telemetry', () => ({
   telemetry: jest.fn(() => Promise.resolve()),
+  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
 }));
 
 describe('withStorybook experimental_mcp', () => {
@@ -62,13 +63,15 @@ describe('withStorybook experimental_mcp', () => {
     expect(generateArgs.port).toBeUndefined();
   });
 
-  test('reports telemetry with the resolved configDir so framework metadata is captured', () => {
+  test('enables telemetry and reports the resolved configDir so framework metadata is sent', () => {
     (optionalEnvToBoolean as jest.Mock).mockReturnValue(false);
 
     withStorybook(config, {
       configPath: '/tmp/.rnstorybook',
       enabled: true,
     });
+
+    expect(setTelemetryEnabled).toHaveBeenCalledWith(true);
     expect(telemetry).toHaveBeenCalledWith(
       'dev',
       {},

--- a/packages/react-native/src/metro/withStorybook.ts
+++ b/packages/react-native/src/metro/withStorybook.ts
@@ -147,7 +147,7 @@ export function withStorybook(
   const server = envVariableToBoolean(process.env.STORYBOOK_SERVER, true);
 
   if (!disableTelemetry && enabled) {
-    telemetry('dev', {}).catch((e) => {});
+    telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
   }
 
   if (!enabled) {

--- a/packages/react-native/src/metro/withStorybook.ts
+++ b/packages/react-native/src/metro/withStorybook.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { generate } from '../../scripts/generate';
 import type { MetroConfig } from 'metro-config';
 import { optionalEnvToBoolean } from 'storybook/internal/common';
-import { telemetry } from 'storybook/internal/telemetry';
+import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
 import { createChannelServer } from './channelServer';
 import type { WebsocketsOptions } from '../types';
 import { envVariableToBoolean, loadWebsocketEnvOverrides } from '../env-tools';
@@ -147,6 +147,7 @@ export function withStorybook(
   const server = envVariableToBoolean(process.env.STORYBOOK_SERVER, true);
 
   if (!disableTelemetry && enabled) {
+    setTelemetryEnabled(true);
     telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
   }
 

--- a/packages/react-native/src/repack/withStorybook.test.ts
+++ b/packages/react-native/src/repack/withStorybook.test.ts
@@ -11,6 +11,7 @@ jest.mock('../../scripts/generate', () => ({
 
 jest.mock('storybook/internal/telemetry', () => ({
   telemetry: jest.fn(() => Promise.resolve()),
+  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
 }));
 
 const { generate } = require('../../scripts/generate') as typeof import('../../scripts/generate');

--- a/packages/react-native/src/repack/withStorybook.ts
+++ b/packages/react-native/src/repack/withStorybook.ts
@@ -3,7 +3,7 @@ import { generate } from '../../scripts/generate';
 import { createChannelServer } from '../metro/channelServer';
 import type { WebsocketsOptions } from '../types';
 import { envVariableToBoolean, loadWebsocketEnvOverrides } from '../env-tools';
-import { telemetry } from 'storybook/internal/telemetry';
+import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
 
 /**
  * Minimal compiler types for webpack/rspack compatibility.
@@ -142,6 +142,7 @@ export class StorybookPlugin {
     const disableTelemetry = envVariableToBoolean(process.env.STORYBOOK_DISABLE_TELEMETRY, false);
 
     if (!disableTelemetry && enabled) {
+      setTelemetryEnabled(true);
       telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
     }
 

--- a/packages/react-native/src/repack/withStorybook.ts
+++ b/packages/react-native/src/repack/withStorybook.ts
@@ -142,7 +142,7 @@ export class StorybookPlugin {
     const disableTelemetry = envVariableToBoolean(process.env.STORYBOOK_DISABLE_TELEMETRY, false);
 
     if (!disableTelemetry && enabled) {
-      telemetry('dev', {}).catch((e) => {});
+      telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
     }
 
     this.applyEnabled(compiler, {

--- a/packages/react-native/src/withStorybook.test.ts
+++ b/packages/react-native/src/withStorybook.test.ts
@@ -14,10 +14,12 @@ jest.mock('storybook/internal/common', () => ({
 
 jest.mock('storybook/internal/telemetry', () => ({
   telemetry: jest.fn(() => Promise.resolve()),
+  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('storybook/internal/telemetry', () => ({
   telemetry: jest.fn(() => Promise.resolve()),
+  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
 }));
 
 describe('withStorybook (unified)', () => {
@@ -46,6 +48,7 @@ describe('withStorybook (unified)', () => {
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
     jest.mock('storybook/internal/telemetry', () => ({
       telemetry: jest.fn(() => Promise.resolve()),
+      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
     }));
 
     const { withStorybook } = require('./withStorybook');
@@ -66,6 +69,7 @@ describe('withStorybook (unified)', () => {
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
     jest.mock('storybook/internal/telemetry', () => ({
       telemetry: jest.fn(() => Promise.resolve()),
+      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
     }));
 
     const { withStorybook } = require('./withStorybook');
@@ -84,6 +88,7 @@ describe('withStorybook (unified)', () => {
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
     jest.mock('storybook/internal/telemetry', () => ({
       telemetry: jest.fn(() => Promise.resolve()),
+      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
     }));
 
     const { generate: mockGenerate } = require('../scripts/generate');
@@ -107,6 +112,7 @@ describe('withStorybook (unified)', () => {
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
     jest.mock('storybook/internal/telemetry', () => ({
       telemetry: jest.fn(() => Promise.resolve()),
+      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
     }));
 
     const { generate: mockGenerate } = require('../scripts/generate');
@@ -133,6 +139,7 @@ describe('withStorybook (unified)', () => {
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
     jest.mock('storybook/internal/telemetry', () => ({
       telemetry: jest.fn(() => Promise.resolve()),
+      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
     }));
 
     const { createChannelServer: mockCreateChannelServer } = require('./metro/channelServer');
@@ -162,6 +169,7 @@ describe('withStorybook (unified)', () => {
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
     jest.mock('storybook/internal/telemetry', () => ({
       telemetry: jest.fn(() => Promise.resolve()),
+      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
     }));
 
     const { createChannelServer: mockCreateChannelServer } = require('./metro/channelServer');
@@ -191,6 +199,7 @@ describe('withStorybook (unified)', () => {
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
     jest.mock('storybook/internal/telemetry', () => ({
       telemetry: jest.fn(() => Promise.resolve()),
+      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
     }));
 
     const { withStorybook } = require('./withStorybook');

--- a/packages/react-native/src/withStorybook.ts
+++ b/packages/react-native/src/withStorybook.ts
@@ -7,7 +7,7 @@ import type { WithStorybookOptions } from './metro/utils';
 import { generate } from '../scripts/generate';
 import { createChannelServer } from './metro/channelServer';
 import { envVariableToBoolean, loadWebsocketEnvOverrides } from './env-tools';
-import { telemetry } from 'storybook/internal/telemetry';
+import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
 
 function isMetroConfig(config: unknown): config is MetroConfig {
   return config != null && typeof config === 'object' && 'transformer' in config;
@@ -31,6 +31,7 @@ export function withStorybook<T extends unknown>(config: T, options: WithStorybo
   const configPath = options.configPath || defaultConfigPath;
 
   if (!disableTelemetry && enabled) {
+    setTelemetryEnabled(true);
     telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
   }
 

--- a/packages/react-native/src/withStorybook.ts
+++ b/packages/react-native/src/withStorybook.ts
@@ -27,8 +27,11 @@ export function withStorybook<T extends unknown>(config: T, options: WithStorybo
   );
   const settings = { ...options };
 
+  const defaultConfigPath = path.resolve(process.cwd(), './.rnstorybook');
+  const configPath = options.configPath || defaultConfigPath;
+
   if (!disableTelemetry && enabled) {
-    telemetry('dev', {}).catch((e) => {});
+    telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
   }
 
   if (!server) {
@@ -39,8 +42,6 @@ export function withStorybook<T extends unknown>(config: T, options: WithStorybo
     settings.docTools = false;
   }
 
-  const defaultConfigPath = path.resolve(process.cwd(), './.rnstorybook');
-  const configPath = options.configPath || defaultConfigPath;
   const websocketsOption = options.websockets;
   const resolvedWs = loadWebsocketEnvOverrides(websocketsOption);
 


### PR DESCRIPTION
Issue: #906 (closes storybookjs/storybook#35462)

React Native runs through Metro/Re.Pack instead of the Storybook core-server, so two things were missing from the `dev` telemetry event:

1. **It was never sent.** The telemetry module gates all calls behind a module-level enabled flag that the core-server normally resolves during preset loading. RN never boots the core-server, so the `dev` event was pushed onto the internal queue and never flushed.
2. **It had no `configDir`.** `telemetry('dev', {})` left `getStorybookMetadata` defaulting to `.storybook`, so it never read `.rnstorybook` and `metadata.framework` was empty.


## What I did


In all three `withStorybook` entry points, resolve the telemetry state and forward the config dir:

```ts
if (!disableTelemetry && enabled) {
  setTelemetryEnabled(true);
  telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
}
```

## How to test

```bash
pnpm --filter @storybook/react-native test
pnpm --filter @storybook/react-native check:types
```

- Does this need a new example in examples/expo-example?
    - No. This doesn't add user-facing behavior; the examples already use `.rnstorybook`.

- Does this need an update to the documentation?
    - No. No public API or setup steps change. This only corrects what telemetry does internally.
