### PR TITLE
fix: attribute RN dev telemetry for existing projects on upgrade

### DIFF
--- a/.changeset/telemetry-framework-in-template.md
+++ b/.changeset/telemetry-framework-in-template.md
@@ -1,0 +1,7 @@
+---
+'@storybook/react-native': patch
+---
+
+Telemetry: attribute React Native `dev` events with `metadata.framework.name` on upgrade
+
+`withStorybook` already sent `dev` telemetry after #907, but existing `.rnstorybook/main` files often omit `framework`, so Metabase could not attribute usage. On enabled Storybook startups we now ensure framework metadata is present without modifying user files (no codemod): use the real config dir when metadata already has a framework name, otherwise send the event via a temporary main that includes `framework: '@storybook/react-native'`. The CLI template also declares `framework` for newly generated projects.

--- a/packages/react-native/src/metro/withStorybook.test.ts
+++ b/packages/react-native/src/metro/withStorybook.test.ts
@@ -2,7 +2,7 @@ import type { MetroConfig } from 'metro-config';
 import { createChannelServer } from './channelServer';
 import { generate } from '../../scripts/generate';
 import { optionalEnvToBoolean } from 'storybook/internal/common';
-import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+import { sendDevTelemetry } from '../telemetry/sendDevTelemetry';
 
 jest.mock('./channelServer', () => ({
   createChannelServer: jest.fn(),
@@ -16,9 +16,8 @@ jest.mock('storybook/internal/common', () => ({
   optionalEnvToBoolean: jest.fn(() => true),
 }));
 
-jest.mock('storybook/internal/telemetry', () => ({
-  telemetry: jest.fn(() => Promise.resolve()),
-  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
+jest.mock('../telemetry/sendDevTelemetry', () => ({
+  sendDevTelemetry: jest.fn(() => Promise.resolve()),
 }));
 
 describe('withStorybook experimental_mcp', () => {
@@ -63,7 +62,7 @@ describe('withStorybook experimental_mcp', () => {
     expect(generateArgs.port).toBeUndefined();
   });
 
-  test('enables telemetry and reports the resolved configDir so framework metadata is sent', () => {
+  test('sends dev telemetry with the resolved configPath when enabled', () => {
     (optionalEnvToBoolean as jest.Mock).mockReturnValue(false);
 
     withStorybook(config, {
@@ -71,12 +70,7 @@ describe('withStorybook experimental_mcp', () => {
       enabled: true,
     });
 
-    expect(setTelemetryEnabled).toHaveBeenCalledWith(true);
-    expect(telemetry).toHaveBeenCalledWith(
-      'dev',
-      {},
-      expect.objectContaining({ configDir: '/tmp/.rnstorybook' })
-    );
+    expect(sendDevTelemetry).toHaveBeenCalledWith('/tmp/.rnstorybook');
   });
 
   test('passes experimental_mcp to channel server when websockets are configured', () => {

--- a/packages/react-native/src/metro/withStorybook.ts
+++ b/packages/react-native/src/metro/withStorybook.ts
@@ -2,10 +2,10 @@ import * as path from 'path';
 import { generate } from '../../scripts/generate';
 import type { MetroConfig } from 'metro-config';
 import { optionalEnvToBoolean } from 'storybook/internal/common';
-import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
 import { createChannelServer } from './channelServer';
 import type { WebsocketsOptions } from '../types';
 import { envVariableToBoolean, loadWebsocketEnvOverrides } from '../env-tools';
+import { sendDevTelemetry } from '../telemetry/sendDevTelemetry';
 
 /**
  * Options for configuring Storybook with React Native.
@@ -147,8 +147,7 @@ export function withStorybook(
   const server = envVariableToBoolean(process.env.STORYBOOK_SERVER, true);
 
   if (!disableTelemetry && enabled) {
-    setTelemetryEnabled(true);
-    telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
+    void sendDevTelemetry(configPath);
   }
 
   if (!enabled) {

--- a/packages/react-native/src/repack/withStorybook.test.ts
+++ b/packages/react-native/src/repack/withStorybook.test.ts
@@ -9,9 +9,8 @@ jest.mock('../../scripts/generate', () => ({
   generate: jest.fn(),
 }));
 
-jest.mock('storybook/internal/telemetry', () => ({
-  telemetry: jest.fn(() => Promise.resolve()),
-  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
+jest.mock('../telemetry/sendDevTelemetry', () => ({
+  sendDevTelemetry: jest.fn(() => Promise.resolve()),
 }));
 
 const { generate } = require('../../scripts/generate') as typeof import('../../scripts/generate');

--- a/packages/react-native/src/repack/withStorybook.ts
+++ b/packages/react-native/src/repack/withStorybook.ts
@@ -3,7 +3,7 @@ import { generate } from '../../scripts/generate';
 import { createChannelServer } from '../metro/channelServer';
 import type { WebsocketsOptions } from '../types';
 import { envVariableToBoolean, loadWebsocketEnvOverrides } from '../env-tools';
-import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+import { sendDevTelemetry } from '../telemetry/sendDevTelemetry';
 
 /**
  * Minimal compiler types for webpack/rspack compatibility.
@@ -142,8 +142,7 @@ export class StorybookPlugin {
     const disableTelemetry = envVariableToBoolean(process.env.STORYBOOK_DISABLE_TELEMETRY, false);
 
     if (!disableTelemetry && enabled) {
-      setTelemetryEnabled(true);
-      telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
+      void sendDevTelemetry(configPath);
     }
 
     this.applyEnabled(compiler, {

--- a/packages/react-native/src/telemetry/sendDevTelemetry.test.ts
+++ b/packages/react-native/src/telemetry/sendDevTelemetry.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { loadMainConfig } from 'storybook/internal/common';
+import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+
+import { sendDevTelemetry } from './sendDevTelemetry';
+
+jest.mock('storybook/internal/common', () => ({
+  loadMainConfig: jest.fn(),
+}));
+
+jest.mock('storybook/internal/telemetry', () => ({
+  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
+  telemetry: jest.fn(() => Promise.resolve()),
+}));
+
+describe('sendDevTelemetry', () => {
+  const configPath = '/tmp/.rnstorybook';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (setTelemetryEnabled as jest.Mock).mockResolvedValue(undefined);
+    (telemetry as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  test('uses the real configDir when main already declares framework', async () => {
+    (loadMainConfig as jest.Mock).mockResolvedValue({
+      stories: [],
+      framework: '@storybook/react-native',
+    });
+
+    await sendDevTelemetry(configPath);
+
+    expect(setTelemetryEnabled).toHaveBeenCalledWith(true);
+    expect(telemetry).toHaveBeenCalledWith(
+      'dev',
+      {},
+      expect.objectContaining({ configDir: configPath, immediate: true })
+    );
+  });
+
+  test('materializes a temporary main with framework when user main omits it', async () => {
+    (loadMainConfig as jest.Mock).mockResolvedValue({
+      stories: ['**/*.stories.tsx'],
+      deviceAddons: ['@storybook/addon-ondevice-controls'],
+    });
+
+    let capturedConfigDir: string | undefined;
+    (telemetry as jest.Mock).mockImplementation(async (_event, _payload, options) => {
+      capturedConfigDir = options.configDir;
+      const mainPath = join(options.configDir, 'main.js');
+      expect(existsSync(mainPath)).toBe(true);
+      const source = readFileSync(mainPath, 'utf8');
+      expect(source).toContain('"@storybook/react-native"');
+      expect(source).toContain('**/*.stories.tsx');
+      expect(source).toContain('@storybook/addon-ondevice-controls');
+    });
+
+    await sendDevTelemetry(configPath);
+
+    expect(capturedConfigDir).toBeDefined();
+    expect(capturedConfigDir).not.toBe(configPath);
+    // temp dir is cleaned up after send
+    expect(existsSync(capturedConfigDir!)).toBe(false);
+  });
+
+  test('never throws when telemetry internals fail', async () => {
+    (loadMainConfig as jest.Mock).mockRejectedValue(new Error('boom'));
+    (setTelemetryEnabled as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    await expect(sendDevTelemetry(configPath)).resolves.toBeUndefined();
+  });
+});

--- a/packages/react-native/src/telemetry/sendDevTelemetry.ts
+++ b/packages/react-native/src/telemetry/sendDevTelemetry.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadMainConfig } from 'storybook/internal/common';
+import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+
+const RN_FRAMEWORK = '@storybook/react-native';
+
+function getFrameworkName(main: unknown): string | undefined {
+  if (main == null || typeof main !== 'object') {
+    return undefined;
+  }
+
+  const framework = (main as { framework?: unknown }).framework;
+  if (typeof framework === 'string') {
+    return framework;
+  }
+  if (
+    framework != null &&
+    typeof framework === 'object' &&
+    typeof (framework as { name?: unknown }).name === 'string'
+  ) {
+    return (framework as { name: string }).name;
+  }
+
+  return undefined;
+}
+
+/**
+ * Pick JSON-serializable main fields telemetry metadata cares about, and force the RN framework.
+ * Used only when the user's main omits `framework`.
+ */
+function buildTelemetryMain(main: Record<string, unknown> | undefined) {
+  return {
+    stories: main?.stories ?? [],
+    addons: main?.addons,
+    deviceAddons: main?.deviceAddons,
+    features: main?.features,
+    typescript: main?.typescript,
+    core: main?.core,
+    refs: main?.refs,
+    staticDirs: main?.staticDirs,
+    framework: RN_FRAMEWORK,
+  };
+}
+
+/**
+ * Send the Storybook `dev` telemetry event for on-device React Native.
+ *
+ * Why not call `telemetry('dev', {}, { configDir })` directly?
+ * `telemetry` builds `metadata.framework` by reading `framework` from the project's main
+ * config. Most existing RN apps omit that field (historical CLI template), so a bare call
+ * leaves `metadata.framework.name` empty and Metabase cannot attribute usage — even though
+ * the event is sent. There is no public option to override metadata, and we must not rewrite
+ * the user's main (no codemod).
+ *
+ * This helper still uses `telemetry` from `storybook/internal/telemetry`. When main already
+ * has `framework`, it passes the real `configDir`. When it does not, it points `configDir` at
+ * a temporary main that includes `framework: '@storybook/react-native'` for that event only,
+ * then deletes the temp dir. Callers must also `setTelemetryEnabled(true)` (done here) because
+ * RN does not boot the Storybook core-server that normally resolves telemetry state.
+ */
+export async function sendDevTelemetry(configPath: string): Promise<void> {
+  let tempDir: string | undefined;
+
+  try {
+    await setTelemetryEnabled(true);
+
+    const main = (await loadMainConfig({ configDir: configPath }).catch(
+      () => undefined
+    )) as Record<string, unknown> | undefined;
+
+    let configDir = configPath;
+
+    if (!getFrameworkName(main)) {
+      tempDir = mkdtempSync(join(tmpdir(), 'sb-rn-telemetry-'));
+      writeFileSync(
+        join(tempDir, 'main.js'),
+        `module.exports = ${JSON.stringify(buildTelemetryMain(main))};\n`
+      );
+      configDir = tempDir;
+    }
+
+    await telemetry('dev', {}, { configDir, immediate: true });
+  } catch {
+    // Telemetry must never break Metro / bundler startup.
+  } finally {
+    if (tempDir) {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // ignore cleanup failures
+      }
+    }
+  }
+}

--- a/packages/react-native/src/withStorybook.test.ts
+++ b/packages/react-native/src/withStorybook.test.ts
@@ -12,14 +12,8 @@ jest.mock('storybook/internal/common', () => ({
   optionalEnvToBoolean: jest.fn(() => true),
 }));
 
-jest.mock('storybook/internal/telemetry', () => ({
-  telemetry: jest.fn(() => Promise.resolve()),
-  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
-}));
-
-jest.mock('storybook/internal/telemetry', () => ({
-  telemetry: jest.fn(() => Promise.resolve()),
-  setTelemetryEnabled: jest.fn(() => Promise.resolve()),
+jest.mock('./telemetry/sendDevTelemetry', () => ({
+  sendDevTelemetry: jest.fn(() => Promise.resolve()),
 }));
 
 describe('withStorybook (unified)', () => {
@@ -39,17 +33,20 @@ describe('withStorybook (unified)', () => {
     jest.resetModules();
   });
 
-  test('returns config unchanged when STORYBOOK_ENABLED is not set', () => {
-    delete process.env.STORYBOOK_ENABLED;
-
+  function remock() {
     jest.resetModules();
     jest.mock('./metro/channelServer', () => ({ createChannelServer: jest.fn() }));
     jest.mock('../scripts/generate', () => ({ generate: jest.fn() }));
     jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
-    jest.mock('storybook/internal/telemetry', () => ({
-      telemetry: jest.fn(() => Promise.resolve()),
-      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
+    jest.mock('./telemetry/sendDevTelemetry', () => ({
+      sendDevTelemetry: jest.fn(() => Promise.resolve()),
     }));
+  }
+
+  test('returns config unchanged when STORYBOOK_ENABLED is not set', () => {
+    delete process.env.STORYBOOK_ENABLED;
+
+    remock();
 
     const { withStorybook } = require('./withStorybook');
     const { generate: mockGenerate } = require('../scripts/generate');
@@ -63,14 +60,7 @@ describe('withStorybook (unified)', () => {
   test('returns config unchanged when STORYBOOK_ENABLED is false', () => {
     process.env.STORYBOOK_ENABLED = 'false';
 
-    jest.resetModules();
-    jest.mock('./metro/channelServer', () => ({ createChannelServer: jest.fn() }));
-    jest.mock('../scripts/generate', () => ({ generate: jest.fn() }));
-    jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
-    jest.mock('storybook/internal/telemetry', () => ({
-      telemetry: jest.fn(() => Promise.resolve()),
-      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
-    }));
+    remock();
 
     const { withStorybook } = require('./withStorybook');
 
@@ -82,14 +72,7 @@ describe('withStorybook (unified)', () => {
   test('detects Metro config and delegates when STORYBOOK_ENABLED=true', () => {
     process.env.STORYBOOK_ENABLED = 'true';
 
-    jest.resetModules();
-    jest.mock('./metro/channelServer', () => ({ createChannelServer: jest.fn() }));
-    jest.mock('../scripts/generate', () => ({ generate: jest.fn() }));
-    jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
-    jest.mock('storybook/internal/telemetry', () => ({
-      telemetry: jest.fn(() => Promise.resolve()),
-      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
-    }));
+    remock();
 
     const { generate: mockGenerate } = require('../scripts/generate');
     const { withStorybook } = require('./withStorybook');
@@ -106,14 +89,7 @@ describe('withStorybook (unified)', () => {
   test('detects rspack/webpack config and calls generate', () => {
     process.env.STORYBOOK_ENABLED = 'true';
 
-    jest.resetModules();
-    jest.mock('./metro/channelServer', () => ({ createChannelServer: jest.fn() }));
-    jest.mock('../scripts/generate', () => ({ generate: jest.fn() }));
-    jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
-    jest.mock('storybook/internal/telemetry', () => ({
-      telemetry: jest.fn(() => Promise.resolve()),
-      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
-    }));
+    remock();
 
     const { generate: mockGenerate } = require('../scripts/generate');
     const { withStorybook } = require('./withStorybook');
@@ -133,14 +109,7 @@ describe('withStorybook (unified)', () => {
     process.env.STORYBOOK_WS_HOST = '10.0.0.5';
     process.env.STORYBOOK_WS_PORT = '9999';
 
-    jest.resetModules();
-    jest.mock('./metro/channelServer', () => ({ createChannelServer: jest.fn() }));
-    jest.mock('../scripts/generate', () => ({ generate: jest.fn() }));
-    jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
-    jest.mock('storybook/internal/telemetry', () => ({
-      telemetry: jest.fn(() => Promise.resolve()),
-      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
-    }));
+    remock();
 
     const { createChannelServer: mockCreateChannelServer } = require('./metro/channelServer');
     const { withStorybook } = require('./withStorybook');
@@ -163,14 +132,7 @@ describe('withStorybook (unified)', () => {
     process.env.STORYBOOK_WS_HOST = '10.0.0.5';
     process.env.STORYBOOK_WS_PORT = '9999';
 
-    jest.resetModules();
-    jest.mock('./metro/channelServer', () => ({ createChannelServer: jest.fn() }));
-    jest.mock('../scripts/generate', () => ({ generate: jest.fn() }));
-    jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
-    jest.mock('storybook/internal/telemetry', () => ({
-      telemetry: jest.fn(() => Promise.resolve()),
-      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
-    }));
+    remock();
 
     const { createChannelServer: mockCreateChannelServer } = require('./metro/channelServer');
     const { withStorybook } = require('./withStorybook');
@@ -193,14 +155,7 @@ describe('withStorybook (unified)', () => {
   test('preserves existing rspack plugins', () => {
     process.env.STORYBOOK_ENABLED = 'true';
 
-    jest.resetModules();
-    jest.mock('./metro/channelServer', () => ({ createChannelServer: jest.fn() }));
-    jest.mock('../scripts/generate', () => ({ generate: jest.fn() }));
-    jest.mock('storybook/internal/common', () => ({ optionalEnvToBoolean: jest.fn(() => true) }));
-    jest.mock('storybook/internal/telemetry', () => ({
-      telemetry: jest.fn(() => Promise.resolve()),
-      setTelemetryEnabled: jest.fn(() => Promise.resolve()),
-    }));
+    remock();
 
     const { withStorybook } = require('./withStorybook');
     const existingPlugin = { apply: jest.fn() };

--- a/packages/react-native/src/withStorybook.ts
+++ b/packages/react-native/src/withStorybook.ts
@@ -7,7 +7,7 @@ import type { WithStorybookOptions } from './metro/utils';
 import { generate } from '../scripts/generate';
 import { createChannelServer } from './metro/channelServer';
 import { envVariableToBoolean, loadWebsocketEnvOverrides } from './env-tools';
-import { setTelemetryEnabled, telemetry } from 'storybook/internal/telemetry';
+import { sendDevTelemetry } from './telemetry/sendDevTelemetry';
 
 function isMetroConfig(config: unknown): config is MetroConfig {
   return config != null && typeof config === 'object' && 'transformer' in config;
@@ -31,8 +31,7 @@ export function withStorybook<T extends unknown>(config: T, options: WithStorybo
   const configPath = options.configPath || defaultConfigPath;
 
   if (!disableTelemetry && enabled) {
-    setTelemetryEnabled(true);
-    telemetry('dev', {}, { configDir: configPath }).catch((e) => {});
+    void sendDevTelemetry(configPath);
   }
 
   if (!server) {

--- a/packages/react-native/template/cli/main.ts
+++ b/packages/react-native/template/cli/main.ts
@@ -3,6 +3,7 @@ import type { StorybookConfig } from '@storybook/react-native';
 const main: StorybookConfig = {
   stories: ['./stories/**/*.stories.?(ts|tsx|js|jsx)'],
   deviceAddons: ['@storybook/addon-ondevice-controls', '@storybook/addon-ondevice-actions'],
+  framework: '@storybook/react-native',
 };
 
 export default main;


### PR DESCRIPTION
## Problem

After [#907](https://github.com/storybookjs/react-native/pull/907) / v10.5.1, RN **does** send `dev` telemetry, but Metabase still looks empty.

Cause: historical `.rnstorybook/main` files omit `framework`. Storybook metadata reads that field for `metadata.framework.name`, so framework-filtered charts miss RN.

A template-only fix is not enough — existing projects keep their old `main` after upgrade.

Refs: [storybookjs/storybook#35462](https://github.com/storybookjs/storybook/issues/35462)

## Solution

Add `sendDevTelemetry(configPath)` and call it from all `withStorybook` entry points (unified / Metro / Re.Pack):

1. If the user’s main already has `framework` → send with the real `configDir`
2. If not → send via a **temporary** main that includes `framework: '@storybook/react-native'`, then delete the temp dir

No user-file writes, no codemod. Upgrading `@storybook/react-native` is enough for **dev** attribution.

Also sets `framework` on the CLI template for newly generated projects (nice-to-have; not the upgrade fix).

## Reviewer focus

| File | Why |
| --- | --- |
| `packages/react-native/src/telemetry/sendDevTelemetry.ts` | The fix |
| `packages/react-native/src/telemetry/sendDevTelemetry.test.ts` | Unit coverage for both branches |
| `**/withStorybook.ts` (3 entry points) | Wiring only — replace raw `telemetry()` with `sendDevTelemetry` |

## Out of scope

**Init** telemetry still goes through Storybook core / `create-storybook`, not `withStorybook`. Needs a companion core PR (`configDir` / `.rnstorybook` discovery). This PR is **dev after upgrade** only.

## How we verified

Against a fixture whose `.rnstorybook/main` **omits** `framework` (existing-project shape):

1. **RED** — old `#907` call (`setTelemetryEnabled` + `configDir` only) → `frameworkName: null`
2. **GREEN** — load `metro.config.js` → this branch’s `withStorybook({ enabled: true })` → `frameworkName: "@storybook/react-native"`
3. Fixture `main` unchanged on disk

Manual repro details are in the PR comments (not checked into the repo).

## Test plan

- [x] Unit tests for `sendDevTelemetry` (framework present / missing / errors)
- [x] All three `withStorybook` entry points call `sendDevTelemetry`
- [x] Manual: Metro-style `withStorybook` load against main without `framework` → `metadata.framework.name === "@storybook/react-native"`
- [x] Manual: user `main` not modified on disk
- [ ] CI green